### PR TITLE
Prepare frames 1 at a time

### DIFF
--- a/src/uploader.c
+++ b/src/uploader.c
@@ -933,8 +933,7 @@ static void push_frame(uv_work_t *work)
         char *exclude_list = calloc(strlen(state->exclude) + 1, sizeof(char));
         if (!exclude_list) {
             req->error_status = STORJ_MEMORY_ERROR;
-            // TODO safe to return here?
-            return;
+            goto clean_variables;
         }
         strcpy(exclude_list, state->exclude);
 
@@ -1109,8 +1108,12 @@ static void push_frame(uv_work_t *work)
     req->status_code = status_code;
 
 clean_variables:
-    json_object_put(response);
-    json_object_put(body);
+    if (response) {
+        json_object_put(response);
+    }
+    if (body) {
+        json_object_put(body);
+    }
 }
 
 static void queue_push_frame(storj_upload_state_t *state, int index)

--- a/src/uploader.h
+++ b/src/uploader.h
@@ -111,7 +111,7 @@ static int prepare_encryption_key(storj_upload_state_t *state,
                                char *pre_salt,
                                int pre_salt_size);
 
-static uint64_t check_file(storj_env_t *env, const char *filepath);
+static int frame_prep_in_progress(storj_upload_state_t *state);
 
 static void shard_meta_cleanup(shard_meta_t *shard_meta);
 static void pointer_cleanup(farmer_pointer_t *farmer_pointer);


### PR DESCRIPTION
If we try to prepare too many frames at once on a disk drive it has trouble reading and takes years to prepare