### PR TITLE
Bring in reedsolomon library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,5 @@ script:
   - ./configure
   - make
   - ./test/tests
+  - ./test/tests_rs
   - make distcheck

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,5 @@
 lib_LTLIBRARIES = libstorj.la
-libstorj_la_SOURCES = storj.c utils.c utils.h http.c http.h uploader.c uploader.h downloader.c downloader.h bip39.c bip39.h bip39_english.h crypto.c crypto.h
+libstorj_la_SOURCES = storj.c utils.c utils.h http.c http.h uploader.c uploader.h downloader.c downloader.h bip39.c bip39.h bip39_english.h crypto.c crypto.h rs.c rs.h
 libstorj_la_LIBADD = -lcurl -lnettle -ljson-c -luv -lm
 libstorj_la_LDFLAGS = -Wall
 include_HEADERS = storj.h

--- a/src/rs.c
+++ b/src/rs.c
@@ -1,0 +1,982 @@
+/*#define PROFILE*/
+/*
+ * fec.c -- forward error correction based on Vandermonde matrices
+ * 980624
+ * (C) 1997-98 Luigi Rizzo (luigi@iet.unipi.it)
+ * (C) 2001 Alain Knaff (alain@knaff.lu)
+ *
+ * Portions derived from code by Phil Karn (karn@ka9q.ampr.org),
+ * Robert Morelos-Zaragoza (robert@spectra.eng.hawaii.edu) and Hari
+ * Thirumoorthy (harit@spectra.eng.hawaii.edu), Aug 1995
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * Reimplement by Jannson (20161018): compatible for golang version of https://github.com/klauspost/reedsolomon
+ */
+
+/*
+ * The following parameter defines how many bits are used for
+ * field elements. The code supports any value from 2 to 16
+ * but fastest operation is achieved with 8 bit elements
+ * This is the only parameter you may want to change.
+ */
+#define GF_BITS  8  /* code over GF(2**GF_BITS) - change to suit */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <assert.h>
+#include "rs.h"
+
+/*
+ * stuff used for testing purposes only
+ */
+
+#ifdef  TEST
+#define DEB(x)
+#define DDB(x) x
+#define DEBUG   0   /* minimal debugging */
+
+#include <sys/time.h>
+#define DIFF_T(a,b) \
+    (1+ 1000000*(a.tv_sec - b.tv_sec) + (a.tv_usec - b.tv_usec) )
+
+#define TICK(t) \
+    {struct timeval x ; \
+    gettimeofday(&x, NULL) ; \
+    t = x.tv_usec + 1000000* (x.tv_sec & 0xff ) ; \
+    }
+#define TOCK(t) \
+    { u_long t1 ; TICK(t1) ; \
+      if (t1 < t) t = 256000000 + t1 - t ; \
+      else t = t1 - t ; \
+      if (t == 0) t = 1 ;}
+
+u_long ticks[10];   /* vars for timekeeping */
+#else
+#define DEB(x)
+#define DDB(x)
+#define TICK(x)
+#define TOCK(x)
+#endif /* TEST */
+
+/*
+ * You should not need to change anything beyond this point.
+ * The first part of the file implements linear algebra in GF.
+ *
+ * gf is the type used to store an element of the Galois Field.
+ * Must constain at least GF_BITS bits.
+ *
+ * Note: unsigned char will work up to GF(256) but int seems to run
+ * faster on the Pentium. We use int whenever have to deal with an
+ * index, since they are generally faster.
+ */
+/*
+ * AK: Udpcast only uses GF_BITS=8. Remove other possibilities
+ */
+#if (GF_BITS != 8)
+#error "GF_BITS must be 8"
+#endif
+typedef unsigned char gf;
+
+#define GF_SIZE ((1 << GF_BITS) - 1)    /* powers of \alpha */
+
+/*
+ * Primitive polynomials - see Lin & Costello, Appendix A,
+ * and  Lee & Messerschmitt, p. 453.
+ */
+static char *allPp[] = {    /* GF_BITS  polynomial      */
+    NULL,           /*  0   no code         */
+    NULL,           /*  1   no code         */
+    "111",          /*  2   1+x+x^2         */
+    "1101",         /*  3   1+x+x^3         */
+    "11001",            /*  4   1+x+x^4         */
+    "101001",           /*  5   1+x^2+x^5       */
+    "1100001",          /*  6   1+x+x^6         */
+    "10010001",         /*  7   1 + x^3 + x^7       */
+    "101110001",        /*  8   1+x^2+x^3+x^4+x^8   */
+    "1000100001",       /*  9   1+x^4+x^9       */
+    "10010000001",      /* 10   1+x^3+x^10      */
+    "101000000001",     /* 11   1+x^2+x^11      */
+    "1100101000001",        /* 12   1+x+x^4+x^6+x^12    */
+    "11011000000001",       /* 13   1+x+x^3+x^4+x^13    */
+    "110000100010001",      /* 14   1+x+x^6+x^10+x^14   */
+    "1100000000000001",     /* 15   1+x+x^15        */
+    "11010000000010001"     /* 16   1+x+x^3+x^12+x^16   */
+};
+
+
+/*
+ * To speed up computations, we have tables for logarithm, exponent
+ * and inverse of a number. If GF_BITS <= 8, we use a table for
+ * multiplication as well (it takes 64K, no big deal even on a PDA,
+ * especially because it can be pre-initialized an put into a ROM!),
+ * otherwhise we use a table of logarithms.
+ * In any case the macro gf_mul(x,y) takes care of multiplications.
+ */
+
+static gf gf_exp[2*GF_SIZE];    /* index->poly form conversion table    */
+static int gf_log[GF_SIZE + 1]; /* Poly->index form conversion table    */
+static gf inverse[GF_SIZE+1];   /* inverse of field elem.       */
+                /* inv[\alpha**i]=\alpha**(GF_SIZE-i-1) */
+
+/*
+ * modnn(x) computes x % GF_SIZE, where GF_SIZE is 2**GF_BITS - 1,
+ * without a slow divide.
+ */
+static inline gf
+modnn(int x)
+{
+    while (x >= GF_SIZE) {
+    x -= GF_SIZE;
+    x = (x >> GF_BITS) + (x & GF_SIZE);
+    }
+    return x;
+}
+
+#define SWAP(a,b,t) {t tmp; tmp=a; a=b; b=tmp;}
+
+/*
+ * gf_mul(x,y) multiplies two numbers. If GF_BITS<=8, it is much
+ * faster to use a multiplication table.
+ *
+ * USE_GF_MULC, GF_MULC0(c) and GF_ADDMULC(x) can be used when multiplying
+ * many numbers by the same constant. In this case the first
+ * call sets the constant, and others perform the multiplications.
+ * A value related to the multiplication is held in a local variable
+ * declared with USE_GF_MULC . See usage in addmul1().
+ */
+static gf gf_mul_table[(GF_SIZE + 1)*(GF_SIZE + 1)]
+#ifdef WINDOWS
+__attribute__((aligned (16)))
+#else
+__attribute__((aligned (256)))
+#endif
+;
+
+#define gf_mul(x,y) gf_mul_table[(x<<8)+y]
+
+#define USE_GF_MULC register gf * __gf_mulc_
+#define GF_MULC0(c) __gf_mulc_ = &gf_mul_table[(c)<<8]
+#define GF_ADDMULC(dst, x) dst ^= __gf_mulc_[x]
+#define GF_MULC(dst, x) dst = __gf_mulc_[x]
+
+static void
+init_mul_table(void)
+{
+    int i, j;
+    for (i=0; i< GF_SIZE+1; i++)
+    for (j=0; j< GF_SIZE+1; j++)
+        gf_mul_table[(i<<8)+j] = gf_exp[modnn(gf_log[i] + gf_log[j]) ] ;
+
+    for (j=0; j< GF_SIZE+1; j++)
+    gf_mul_table[j] = gf_mul_table[j<<8] = 0;
+}
+
+/*
+ * Generate GF(2**m) from the irreducible polynomial p(X) in p[0]..p[m]
+ * Lookup tables:
+ *     index->polynomial form       gf_exp[] contains j= \alpha^i;
+ *     polynomial form -> index form    gf_log[ j = \alpha^i ] = i
+ * \alpha=x is the primitive element of GF(2^m)
+ *
+ * For efficiency, gf_exp[] has size 2*GF_SIZE, so that a simple
+ * multiplication of two numbers can be resolved without calling modnn
+ */
+
+
+
+/*
+ * initialize the data structures used for computations in GF.
+ */
+static void
+generate_gf(void)
+{
+    int i;
+    gf mask;
+    char *Pp =  allPp[GF_BITS] ;
+
+    mask = 1;   /* x ** 0 = 1 */
+    gf_exp[GF_BITS] = 0; /* will be updated at the end of the 1st loop */
+    /*
+     * first, generate the (polynomial representation of) powers of \alpha,
+     * which are stored in gf_exp[i] = \alpha ** i .
+     * At the same time build gf_log[gf_exp[i]] = i .
+     * The first GF_BITS powers are simply bits shifted to the left.
+     */
+    for (i = 0; i < GF_BITS; i++, mask <<= 1 ) {
+    gf_exp[i] = mask;
+    gf_log[gf_exp[i]] = i;
+    /*
+     * If Pp[i] == 1 then \alpha ** i occurs in poly-repr
+     * gf_exp[GF_BITS] = \alpha ** GF_BITS
+     */
+    if ( Pp[i] == '1' )
+        gf_exp[GF_BITS] ^= mask;
+    }
+    /*
+     * now gf_exp[GF_BITS] = \alpha ** GF_BITS is complete, so can als
+     * compute its inverse.
+     */
+    gf_log[gf_exp[GF_BITS]] = GF_BITS;
+    /*
+     * Poly-repr of \alpha ** (i+1) is given by poly-repr of
+     * \alpha ** i shifted left one-bit and accounting for any
+     * \alpha ** GF_BITS term that may occur when poly-repr of
+     * \alpha ** i is shifted.
+     */
+    mask = 1 << (GF_BITS - 1 ) ;
+    for (i = GF_BITS + 1; i < GF_SIZE; i++) {
+    if (gf_exp[i - 1] >= mask)
+        gf_exp[i] = gf_exp[GF_BITS] ^ ((gf_exp[i - 1] ^ mask) << 1);
+    else
+        gf_exp[i] = gf_exp[i - 1] << 1;
+    gf_log[gf_exp[i]] = i;
+    }
+    /*
+     * log(0) is not defined, so use a special value
+     */
+    gf_log[0] = GF_SIZE ;
+    /* set the extended gf_exp values for fast multiply */
+    for (i = 0 ; i < GF_SIZE ; i++)
+    gf_exp[i + GF_SIZE] = gf_exp[i] ;
+
+    /*
+     * again special cases. 0 has no inverse. This used to
+     * be initialized to GF_SIZE, but it should make no difference
+     * since noone is supposed to read from here.
+     */
+    inverse[0] = 0 ;
+    inverse[1] = 1;
+    for (i=2; i<=GF_SIZE; i++)
+    inverse[i] = gf_exp[GF_SIZE-gf_log[i]];
+}
+
+/*
+ * Various linear algebra operations that i use often.
+ */
+
+/*
+ * addmul() computes dst[] = dst[] + c * src[]
+ * This is used often, so better optimize it! Currently the loop is
+ * unrolled 16 times, a good value for 486 and pentium-class machines.
+ * The case c=0 is also optimized, whereas c=1 is not. These
+ * calls are unfrequent in my typical apps so I did not bother.
+ *
+ * Note that gcc on
+ */
+#if 0
+#define addmul(dst, src, c, sz) \
+    if (c != 0) addmul1(dst, src, c, sz)
+#endif
+
+
+
+#define UNROLL 16 /* 1, 4, 8, 16 */
+static void
+slow_addmul1(gf *dst1, gf *src1, gf c, int sz)
+{
+    USE_GF_MULC ;
+    register gf *dst = dst1, *src = src1 ;
+    gf *lim = &dst[sz - UNROLL + 1] ;
+
+    GF_MULC0(c) ;
+
+#if (UNROLL > 1) /* unrolling by 8/16 is quite effective on the pentium */
+    for (; dst < lim ; dst += UNROLL, src += UNROLL ) {
+    GF_ADDMULC( dst[0] , src[0] );
+    GF_ADDMULC( dst[1] , src[1] );
+    GF_ADDMULC( dst[2] , src[2] );
+    GF_ADDMULC( dst[3] , src[3] );
+#if (UNROLL > 4)
+    GF_ADDMULC( dst[4] , src[4] );
+    GF_ADDMULC( dst[5] , src[5] );
+    GF_ADDMULC( dst[6] , src[6] );
+    GF_ADDMULC( dst[7] , src[7] );
+#endif
+#if (UNROLL > 8)
+    GF_ADDMULC( dst[8] , src[8] );
+    GF_ADDMULC( dst[9] , src[9] );
+    GF_ADDMULC( dst[10] , src[10] );
+    GF_ADDMULC( dst[11] , src[11] );
+    GF_ADDMULC( dst[12] , src[12] );
+    GF_ADDMULC( dst[13] , src[13] );
+    GF_ADDMULC( dst[14] , src[14] );
+    GF_ADDMULC( dst[15] , src[15] );
+#endif
+    }
+#endif
+    lim += UNROLL - 1 ;
+    for (; dst < lim; dst++, src++ )        /* final components */
+    GF_ADDMULC( *dst , *src );
+}
+
+# define addmul1 slow_addmul1
+
+static void addmul(gf *dst, gf *src, gf c, int sz) {
+    // fprintf(stderr, "Dst=%p Src=%p, gf=%02x sz=%d\n", dst, src, c, sz);
+    if (c != 0) addmul1(dst, src, c, sz);
+}
+
+/*
+ * mul() computes dst[] = c * src[]
+ * This is used often, so better optimize it! Currently the loop is
+ * unrolled 16 times, a good value for 486 and pentium-class machines.
+ * The case c=0 is also optimized, whereas c=1 is not. These
+ * calls are unfrequent in my typical apps so I did not bother.
+ *
+ * Note that gcc on
+ */
+#if 0
+#define mul(dst, src, c, sz) \
+    do { if (c != 0) mul1(dst, src, c, sz); else memset(dst, 0, c); } while(0)
+#endif
+
+#define UNROLL 16 /* 1, 4, 8, 16 */
+static void
+slow_mul1(gf *dst1, gf *src1, gf c, int sz)
+{
+    USE_GF_MULC ;
+    register gf *dst = dst1, *src = src1 ;
+    gf *lim = &dst[sz - UNROLL + 1] ;
+
+    GF_MULC0(c) ;
+
+#if (UNROLL > 1) /* unrolling by 8/16 is quite effective on the pentium */
+    for (; dst < lim ; dst += UNROLL, src += UNROLL ) {
+    GF_MULC( dst[0] , src[0] );
+    GF_MULC( dst[1] , src[1] );
+    GF_MULC( dst[2] , src[2] );
+    GF_MULC( dst[3] , src[3] );
+#if (UNROLL > 4)
+    GF_MULC( dst[4] , src[4] );
+    GF_MULC( dst[5] , src[5] );
+    GF_MULC( dst[6] , src[6] );
+    GF_MULC( dst[7] , src[7] );
+#endif
+#if (UNROLL > 8)
+    GF_MULC( dst[8] , src[8] );
+    GF_MULC( dst[9] , src[9] );
+    GF_MULC( dst[10] , src[10] );
+    GF_MULC( dst[11] , src[11] );
+    GF_MULC( dst[12] , src[12] );
+    GF_MULC( dst[13] , src[13] );
+    GF_MULC( dst[14] , src[14] );
+    GF_MULC( dst[15] , src[15] );
+#endif
+    }
+#endif
+    lim += UNROLL - 1 ;
+    for (; dst < lim; dst++, src++ )        /* final components */
+    GF_MULC( *dst , *src );
+}
+
+# define mul1 slow_mul1
+
+static inline void mul(gf *dst, gf *src, gf c, int sz) {
+    /*fprintf(stderr, "%p = %02x * %p\n", dst, c, src);*/
+    if (c != 0) mul1(dst, src, c, sz); else memset(dst, 0, c);
+}
+
+/*
+ * invert_mat() takes a matrix and produces its inverse
+ * k is the size of the matrix.
+ * (Gauss-Jordan, adapted from Numerical Recipes in C)
+ * Return non-zero if singular.
+ */
+DEB( int pivloops=0; int pivswaps=0 ; /* diagnostic */)
+    static int
+invert_mat(gf *src, int k)
+{
+    gf c, *p ;
+    int irow, icol, row, col, i, ix ;
+
+    int error = 1 ;
+    int indxc[k];
+    int indxr[k];
+    int ipiv[k];
+    gf id_row[k];
+
+    memset(id_row, 0, k*sizeof(gf));
+    DEB( pivloops=0; pivswaps=0 ; /* diagnostic */ )
+    /*
+     * ipiv marks elements already used as pivots.
+     */
+    for (i = 0; i < k ; i++)
+        ipiv[i] = 0 ;
+
+    for (col = 0; col < k ; col++) {
+    gf *pivot_row ;
+    /*
+     * Zeroing column 'col', look for a non-zero element.
+     * First try on the diagonal, if it fails, look elsewhere.
+     */
+    irow = icol = -1 ;
+    if (ipiv[col] != 1 && src[col*k + col] != 0) {
+        irow = col ;
+        icol = col ;
+        goto found_piv ;
+    }
+    for (row = 0 ; row < k ; row++) {
+        if (ipiv[row] != 1) {
+        for (ix = 0 ; ix < k ; ix++) {
+            DEB( pivloops++ ; )
+            if (ipiv[ix] == 0) {
+                if (src[row*k + ix] != 0) {
+                irow = row ;
+                icol = ix ;
+                goto found_piv ;
+                }
+            } else if (ipiv[ix] > 1) {
+                fprintf(stderr, "singular matrix\n");
+                goto fail ;
+            }
+        }
+        }
+    }
+    if (icol == -1) {
+        fprintf(stderr, "XXX pivot not found!\n");
+        goto fail ;
+    }
+ found_piv:
+    ++(ipiv[icol]) ;
+    /*
+     * swap rows irow and icol, so afterwards the diagonal
+     * element will be correct. Rarely done, not worth
+     * optimizing.
+     */
+    if (irow != icol) {
+        for (ix = 0 ; ix < k ; ix++ ) {
+        SWAP( src[irow*k + ix], src[icol*k + ix], gf) ;
+        }
+    }
+    indxr[col] = irow ;
+    indxc[col] = icol ;
+    pivot_row = &src[icol*k] ;
+    c = pivot_row[icol] ;
+    if (c == 0) {
+        fprintf(stderr, "singular matrix 2\n");
+        goto fail ;
+    }
+    if (c != 1 ) { /* otherwhise this is a NOP */
+        /*
+         * this is done often , but optimizing is not so
+         * fruitful, at least in the obvious ways (unrolling)
+         */
+        DEB( pivswaps++ ; )
+        c = inverse[ c ] ;
+        pivot_row[icol] = 1 ;
+        for (ix = 0 ; ix < k ; ix++ )
+        pivot_row[ix] = gf_mul(c, pivot_row[ix] );
+    }
+    /*
+     * from all rows, remove multiples of the selected row
+     * to zero the relevant entry (in fact, the entry is not zero
+     * because we know it must be zero).
+     * (Here, if we know that the pivot_row is the identity,
+     * we can optimize the addmul).
+     */
+    id_row[icol] = 1;
+    if (memcmp(pivot_row, id_row, k*sizeof(gf)) != 0) {
+        for (p = src, ix = 0 ; ix < k ; ix++, p += k ) {
+        if (ix != icol) {
+            c = p[icol] ;
+            p[icol] = 0 ;
+            addmul(p, pivot_row, c, k );
+        }
+        }
+    }
+    id_row[icol] = 0;
+    } /* done all columns */
+    for (col = k-1 ; col >= 0 ; col-- ) {
+    if (indxr[col] <0 || indxr[col] >= k)
+        fprintf(stderr, "AARGH, indxr[col] %d\n", indxr[col]);
+    else if (indxc[col] <0 || indxc[col] >= k)
+        fprintf(stderr, "AARGH, indxc[col] %d\n", indxc[col]);
+    else
+        if (indxr[col] != indxc[col] ) {
+        for (row = 0 ; row < k ; row++ ) {
+            SWAP( src[row*k + indxr[col]], src[row*k + indxc[col]], gf) ;
+        }
+        }
+    }
+    error = 0 ;
+ fail:
+    return error ;
+}
+
+static int fec_initialized = 0 ;
+
+void fec_init(void)
+{
+    TICK(ticks[0]);
+    generate_gf();
+    TOCK(ticks[0]);
+    DDB(fprintf(stderr, "generate_gf took %ldus\n", ticks[0]);)
+    TICK(ticks[0]);
+    init_mul_table();
+    TOCK(ticks[0]);
+    DDB(fprintf(stderr, "init_mul_table took %ldus\n", ticks[0]);)
+    fec_initialized = 1 ;
+}
+
+
+#ifdef PROFILE
+static long long rdtsc(void)
+{
+    unsigned long low, hi;
+    asm volatile ("rdtsc" : "=d" (hi), "=a" (low));
+    return ( (((long long)hi) << 32) | ((long long) low));
+}
+
+void print_matrix1(gf* matrix, int nrows, int ncols) {
+    int i, j;
+    printf("matrix (%d,%d):\n", nrows, ncols);
+    for(i = 0; i < nrows; i++) {
+        for(j = 0; j < ncols; j++) {
+            printf("%6d ", matrix[i*ncols + j]);
+        }
+        printf("\n");
+    }
+}
+
+void print_matrix2(gf** matrix, int nrows, int ncols) {
+    int i, j;
+    printf("matrix (%d,%d):\n", nrows, ncols);
+    for(i = 0; i < nrows; i++) {
+        for(j = 0; j < ncols; j++) {
+            printf("%6d ", matrix[i][j]);
+        }
+        printf("\n");
+    }
+}
+
+#endif
+
+/* y = a**n */
+static gf galExp(gf a, gf n) {
+    int logA;
+    int logResult;
+    if(0 == n) {
+        return 1;
+    }
+    if(0 == a) {
+        return 0;
+    }
+    logA = gf_log[a];
+    logResult = logA * n;
+    while(logResult >= 255) {
+        logResult -= 255;
+    }
+
+    return gf_exp[logResult];
+}
+
+static inline gf galMultiply(gf a, gf b) {
+    return gf_mul_table[ ((int)a << 8) + (int)b ];
+}
+
+static gf* vandermonde(int nrows, int ncols) {
+    int row, col, ptr;
+    gf* matrix = (gf*)RS_MALLOC(nrows * ncols);
+    if(NULL != matrix) {
+        ptr = 0;
+        for(row = 0; row < nrows; row++) {
+            for(col = 0; col < ncols; col++) {
+                matrix[ptr++] = galExp((gf)row, (gf)col);
+            }
+        }
+    }
+
+    return matrix;
+}
+
+/*
+ * Not check for input params
+ * */
+static gf* sub_matrix(gf* matrix, int rmin, int cmin, int rmax, int cmax,  int nrows, int ncols) {
+    int i, j, ptr = 0;
+    gf* new_m = (gf*)RS_MALLOC( (rmax-rmin) * (cmax-cmin) );
+    if(NULL != new_m) {
+        for(i = rmin; i < rmax; i++) {
+            for(j = cmin; j < cmax; j++) {
+                new_m[ptr++] = matrix[i*ncols + j];
+            }
+        }
+    }
+
+    return new_m;
+}
+
+/* y = a.dot(b) */
+static gf* multiply1(gf *a, int ar, int ac, gf *b, int br, int bc) {
+    gf *new_m, tg;
+    int r, c, i, ptr = 0;
+
+    assert(ac == br);
+    new_m = (gf*)RS_CALLOC(1, ar*bc);
+    if(NULL != new_m) {
+
+        /* this multiply is slow */
+        for(r = 0; r < ar; r++) {
+            for(c = 0; c < bc; c++) {
+                tg = 0;
+                for(i = 0; i < ac; i++) {
+                    /* tg ^= gf_mul_table[ ((int)a[r*ac+i] << 8) + (int)b[i*bc+c] ]; */
+                    tg ^= galMultiply(a[r*ac+i], b[i*bc+c]);
+                }
+
+                new_m[ptr++] = tg;
+            }
+        }
+
+    }
+
+    return new_m;
+}
+
+/* copy from golang rs version */
+static inline int code_some_shards(gf* matrixRows, gf** inputs, gf** outputs,
+        int dataShards, int outputCount, int byteCount) {
+    gf* in;
+    int iRow, c;
+    for(c = 0; c < dataShards; c++) {
+        in = inputs[c];
+        for(iRow = 0; iRow < outputCount; iRow++) {
+            if(0 == c) {
+                mul(outputs[iRow], in, matrixRows[iRow*dataShards+c], byteCount);
+            } else {
+                addmul(outputs[iRow], in, matrixRows[iRow*dataShards+c], byteCount);
+            }
+        }
+    }
+
+    return 0;
+}
+
+reed_solomon* reed_solomon_new(int data_shards, int parity_shards) {
+    gf* vm = NULL;
+    gf* top = NULL;
+    int err = 0;
+    reed_solomon* rs = NULL;
+
+    /* MUST use fec_init once time first */
+    assert(fec_initialized);
+
+    do {
+        rs = RS_MALLOC(sizeof(reed_solomon));
+        if(NULL == rs) {
+            return NULL;
+        }
+        rs->data_shards = data_shards;
+        rs->parity_shards = parity_shards;
+        rs->shards = (data_shards + parity_shards);
+        rs->m = NULL;
+        rs->parity = NULL;
+
+        if(rs->shards > DATA_SHARDS_MAX || data_shards <= 0 || parity_shards <= 0) {
+            err = 1;
+            break;
+        }
+
+        vm = vandermonde(rs->shards, rs->data_shards);
+        if(NULL == vm) {
+            err = 2;
+            break;
+        }
+
+        top = sub_matrix(vm, 0, 0, data_shards, data_shards, rs->shards, data_shards);
+        if(NULL == top) {
+            err = 3;
+            break;
+        }
+
+        err = invert_mat(top, data_shards);
+        assert(0 == err);
+
+        rs->m = multiply1(vm, rs->shards, data_shards, top, data_shards, data_shards);
+        if(NULL == rs->m) {
+            err = 4;
+            break;
+        }
+
+        rs->parity = sub_matrix(rs->m, data_shards, 0, rs->shards, data_shards, rs->shards, data_shards);
+        if(NULL == rs->parity) {
+            err = 5;
+            break;
+        }
+
+        RS_FREE(vm);
+        RS_FREE(top);
+        vm = NULL;
+        top = NULL;
+        return rs;
+
+    } while(0);
+
+    fprintf(stderr, "err=%d\n", err);
+    if(NULL != vm) {
+        RS_FREE(vm);
+    }
+    if(NULL != top) {
+        RS_FREE(top);
+    }
+    if(NULL != rs) {
+        if(NULL != rs->m) {
+            RS_FREE(rs->m);
+        }
+        if(NULL != rs->parity) {
+            RS_FREE(rs->parity);
+        }
+        RS_FREE(rs);
+    }
+
+    return NULL;
+}
+
+void reed_solomon_release(reed_solomon* rs) {
+    if(NULL != rs) {
+        if(NULL != rs->m) {
+            RS_FREE(rs->m);
+        }
+        if(NULL != rs->parity) {
+            RS_FREE(rs->parity);
+        }
+        RS_FREE(rs);
+    }
+}
+
+/**
+ * encode one shard
+ * input:
+ * rs
+ * data_blocks[rs->data_shards][block_size]
+ * fec_blocks[rs->data_shards][block_size]
+ * */
+int reed_solomon_encode(reed_solomon* rs,
+        unsigned char** data_blocks,
+        unsigned char** fec_blocks,
+        int block_size) {
+    assert(NULL != rs && NULL != rs->parity);
+
+    return code_some_shards(rs->parity, data_blocks, fec_blocks
+            , rs->data_shards, rs->parity_shards, block_size);
+}
+
+/**
+ * decode one shard
+ * input:
+ * rs
+ * original data_blocks[rs->data_shards][block_size]
+ * dec_fec_blocks[nr_fec_blocks][block_size]
+ * fec_block_nos: fec pos number in original fec_blocks
+ * erased_blocks: erased blocks in original data_blocks
+ * nr_fec_blocks: the number of erased blocks
+ * */
+int reed_solomon_decode(reed_solomon* rs,
+        unsigned char **data_blocks,
+        int block_size,
+        unsigned char **dec_fec_blocks,
+        unsigned int *fec_block_nos,
+        unsigned int *erased_blocks,
+        int nr_fec_blocks) {
+    /* use stack instead of malloc, define a small number of DATA_SHARDS_MAX to save memory */
+    gf dataDecodeMatrix[DATA_SHARDS_MAX*DATA_SHARDS_MAX];
+    unsigned char* subShards[DATA_SHARDS_MAX];
+    unsigned char* outputs[DATA_SHARDS_MAX];
+    gf* m = rs->m;
+    int i, j, c, swap, subMatrixRow, dataShards, nos, nshards;
+
+    /* the erased_blocks should always sorted
+     * if sorted, nr_fec_blocks times to check it
+     * if not, sort it here
+     * */
+    for(i = 0; i < nr_fec_blocks; i++) {
+        swap = 0;
+        for(j = i+1; j < nr_fec_blocks; j++) {
+            if(erased_blocks[i] > erased_blocks[j]) {
+                /* the prefix is bigger than the following, swap */
+                c = erased_blocks[i];
+                erased_blocks[i] = erased_blocks[j];
+                erased_blocks[j] = c;
+
+                swap = 1;
+            }
+        }
+        //printf("swap:%d\n", swap);
+        if(!swap) {
+            //already sorted or sorted ok
+            break;
+        }
+    }
+
+    j = 0;
+    subMatrixRow = 0;
+    nos = 0;
+    nshards = 0;
+    dataShards = rs->data_shards;
+    for(i = 0; i < dataShards; i++) {
+        if(j < nr_fec_blocks && i == erased_blocks[j]) {
+            //ignore the invalid block
+            j++;
+        } else {
+            /* this row is ok */
+            for(c = 0; c < dataShards; c++) {
+                dataDecodeMatrix[subMatrixRow*dataShards + c] = m[i*dataShards + c];
+            }
+            subShards[subMatrixRow] = data_blocks[i];
+            subMatrixRow++;
+        }
+    }
+
+    for(i = 0; i < nr_fec_blocks && subMatrixRow < dataShards; i++) {
+        subShards[subMatrixRow] = dec_fec_blocks[i];
+        j = dataShards + fec_block_nos[i];
+        for(c = 0; c < dataShards; c++) {
+            dataDecodeMatrix[subMatrixRow*dataShards + c] = m[j*dataShards + c]; //use spefic pos of original fec_blocks
+        }
+        subMatrixRow++;
+    }
+
+    if(subMatrixRow < dataShards) {
+        //cannot correct
+        return -1;
+    }
+
+    invert_mat(dataDecodeMatrix, dataShards);
+    //printf("invert:\n");
+    //print_matrix1(dataDecodeMatrix, dataShards, dataShards);
+    //printf("nShards:\n");
+    //print_matrix2(subShards, dataShards, block_size);
+
+    for(i = 0; i < nr_fec_blocks; i++) {
+        j = erased_blocks[i];
+        outputs[i] = data_blocks[j];
+        //data_blocks[j][0] = 0;
+        memmove(dataDecodeMatrix+i*dataShards, dataDecodeMatrix+j*dataShards, dataShards);
+    }
+    //printf("subMatrixRow:\n");
+    //print_matrix1(dataDecodeMatrix, nr_fec_blocks, dataShards);
+
+    //printf("outputs:\n");
+    //print_matrix2(outputs, nr_fec_blocks, block_size);
+
+    return code_some_shards(dataDecodeMatrix, subShards, outputs,
+            dataShards, nr_fec_blocks, block_size);
+}
+
+/**
+ * encode a big size of buffer
+ * input:
+ * rs
+ * nr_shards: assert(0 == nr_shards % rs->shards)
+ * shards[nr_shards][block_size]
+ * */
+int reed_solomon_encode2(reed_solomon* rs, unsigned char** shards, int nr_shards, int block_size) {
+    unsigned char** data_blocks;
+    unsigned char** fec_blocks;
+    int i, ds = rs->data_shards, ps = rs->parity_shards, ss = rs->shards;
+    i = nr_shards / ss;
+    data_blocks = shards;
+    fec_blocks = &shards[(i*ds)];
+
+    for(i = 0; i < nr_shards; i += ss) {
+        reed_solomon_encode(rs, data_blocks, fec_blocks, block_size);
+        data_blocks += ds;
+        fec_blocks += ps;
+    }
+    return 0;
+}
+
+/**
+ * reconstruct a big size of buffer
+ * input:
+ * rs
+ * nr_shards: assert(0 == nr_shards % rs->data_shards)
+ * shards[nr_shards][block_size]
+ * marks[nr_shards] marks as errors
+ * */
+int reed_solomon_reconstruct(reed_solomon* rs,
+        unsigned char** shards,
+        unsigned char* marks,
+        int nr_shards,
+        int block_size) {
+    unsigned char *dec_fec_blocks[DATA_SHARDS_MAX];
+    unsigned int fec_block_nos[DATA_SHARDS_MAX];
+    unsigned int erased_blocks[DATA_SHARDS_MAX];
+    unsigned char* fec_marks;
+    unsigned char **data_blocks, **fec_blocks;
+    int i, j, dn, pn, n;
+    int ds = rs->data_shards;
+    int ps = rs->parity_shards;
+    int err = 0;
+
+    data_blocks = shards;
+    n = nr_shards / rs->shards;
+    fec_marks = marks + n*ds; //after all data, is't fec marks
+    fec_blocks = shards + n*ds;
+
+    for(j = 0; j < n; j++) {
+        dn = 0;
+        for(i = 0; i < ds; i++) {
+            if(marks[i]) {
+                //errors
+                erased_blocks[dn++] = i;
+            }
+        }
+        if(dn > 0) {
+            pn = 0;
+            for(i = 0; i < ps && pn < dn; i++) {
+                if(!fec_marks[i]) {
+                    //got valid fec row
+                    fec_block_nos[pn] = i;
+                    dec_fec_blocks[pn] = fec_blocks[i];
+                    pn++;
+                }
+            }
+
+            if(dn == pn) {
+                reed_solomon_decode(rs
+                        , data_blocks
+                        , block_size
+                        , dec_fec_blocks
+                        , fec_block_nos
+                        , erased_blocks
+                        , dn);
+            } else {
+                //error but we continue
+                err = -1;
+            }
+        }
+        data_blocks += ds;
+        marks += ds;
+        fec_blocks += ps;
+        fec_marks += ps;
+    }
+
+    return err;
+}
+

--- a/src/rs.c
+++ b/src/rs.c
@@ -148,8 +148,7 @@ static gf inverse[GF_SIZE+1];   /* inverse of field elem.       */
  * modnn(x) computes x % GF_SIZE, where GF_SIZE is 2**GF_BITS - 1,
  * without a slow divide.
  */
-static inline gf
-modnn(int x)
+static inline gf modnn(int x)
 {
     while (x >= GF_SIZE) {
     x -= GF_SIZE;
@@ -185,8 +184,7 @@ __attribute__((aligned (256)))
 #define GF_ADDMULC(dst, x) dst ^= __gf_mulc_[x]
 #define GF_MULC(dst, x) dst = __gf_mulc_[x]
 
-static void
-init_mul_table(void)
+static void init_mul_table(void)
 {
     int i, j;
     for (i=0; i< GF_SIZE+1; i++)
@@ -213,8 +211,7 @@ init_mul_table(void)
 /*
  * initialize the data structures used for computations in GF.
  */
-static void
-generate_gf(void)
+static void generate_gf(void)
 {
     int i;
     gf mask;
@@ -297,8 +294,7 @@ generate_gf(void)
 
 
 #define UNROLL 16 /* 1, 4, 8, 16 */
-static void
-slow_addmul1(gf *dst1, gf *src1, gf c, int sz)
+static void slow_addmul1(gf *dst1, gf *src1, gf c, int sz)
 {
     USE_GF_MULC ;
     register gf *dst = dst1, *src = src1 ;
@@ -337,7 +333,8 @@ slow_addmul1(gf *dst1, gf *src1, gf c, int sz)
 
 # define addmul1 slow_addmul1
 
-static void addmul(gf *dst, gf *src, gf c, int sz) {
+static void addmul(gf *dst, gf *src, gf c, int sz)
+{
     // fprintf(stderr, "Dst=%p Src=%p, gf=%02x sz=%d\n", dst, src, c, sz);
     if (c != 0) addmul1(dst, src, c, sz);
 }
@@ -357,8 +354,7 @@ static void addmul(gf *dst, gf *src, gf c, int sz) {
 #endif
 
 #define UNROLL 16 /* 1, 4, 8, 16 */
-static void
-slow_mul1(gf *dst1, gf *src1, gf c, int sz)
+static void slow_mul1(gf *dst1, gf *src1, gf c, int sz)
 {
     USE_GF_MULC ;
     register gf *dst = dst1, *src = src1 ;
@@ -397,7 +393,8 @@ slow_mul1(gf *dst1, gf *src1, gf c, int sz)
 
 # define mul1 slow_mul1
 
-static inline void mul(gf *dst, gf *src, gf c, int sz) {
+static inline void mul(gf *dst, gf *src, gf c, int sz)
+{
     /*fprintf(stderr, "%p = %02x * %p\n", dst, c, src);*/
     if (c != 0) mul1(dst, src, c, sz); else memset(dst, 0, c);
 }
@@ -409,8 +406,7 @@ static inline void mul(gf *dst, gf *src, gf c, int sz) {
  * Return non-zero if singular.
  */
 DEB( int pivloops=0; int pivswaps=0 ; /* diagnostic */)
-    static int
-invert_mat(gf *src, int k)
+static int invert_mat(gf *src, int k)
 {
     gf c, *p ;
     int irow, icol, row, col, i, ix ;
@@ -553,7 +549,8 @@ static long long rdtsc(void)
     return ( (((long long)hi) << 32) | ((long long) low));
 }
 
-void print_matrix1(gf* matrix, int nrows, int ncols) {
+void print_matrix1(gf* matrix, int nrows, int ncols)
+{
     int i, j;
     printf("matrix (%d,%d):\n", nrows, ncols);
     for(i = 0; i < nrows; i++) {
@@ -564,7 +561,8 @@ void print_matrix1(gf* matrix, int nrows, int ncols) {
     }
 }
 
-void print_matrix2(gf** matrix, int nrows, int ncols) {
+void print_matrix2(gf** matrix, int nrows, int ncols)
+{
     int i, j;
     printf("matrix (%d,%d):\n", nrows, ncols);
     for(i = 0; i < nrows; i++) {
@@ -578,7 +576,8 @@ void print_matrix2(gf** matrix, int nrows, int ncols) {
 #endif
 
 /* y = a**n */
-static gf galExp(gf a, gf n) {
+static gf galExp(gf a, gf n)
+{
     int logA;
     int logResult;
     if(0 == n) {
@@ -596,11 +595,13 @@ static gf galExp(gf a, gf n) {
     return gf_exp[logResult];
 }
 
-static inline gf galMultiply(gf a, gf b) {
+static inline gf galMultiply(gf a, gf b)
+{
     return gf_mul_table[ ((int)a << 8) + (int)b ];
 }
 
-static gf* vandermonde(int nrows, int ncols) {
+static gf* vandermonde(int nrows, int ncols)
+{
     int row, col, ptr;
     gf* matrix = (gf*)RS_MALLOC(nrows * ncols);
     if(NULL != matrix) {
@@ -618,7 +619,9 @@ static gf* vandermonde(int nrows, int ncols) {
 /*
  * Not check for input params
  * */
-static gf* sub_matrix(gf* matrix, int rmin, int cmin, int rmax, int cmax,  int nrows, int ncols) {
+static gf* sub_matrix(gf* matrix, int rmin, int cmin, int rmax, int cmax,
+                      int nrows, int ncols)
+{
     int i, j, ptr = 0;
     gf* new_m = (gf*)RS_MALLOC( (rmax-rmin) * (cmax-cmin) );
     if(NULL != new_m) {
@@ -633,7 +636,8 @@ static gf* sub_matrix(gf* matrix, int rmin, int cmin, int rmax, int cmax,  int n
 }
 
 /* y = a.dot(b) */
-static gf* multiply1(gf *a, int ar, int ac, gf *b, int br, int bc) {
+static gf* multiply1(gf *a, int ar, int ac, gf *b, int br, int bc)
+{
     gf *new_m, tg;
     int r, c, i, ptr = 0;
 
@@ -661,7 +665,9 @@ static gf* multiply1(gf *a, int ar, int ac, gf *b, int br, int bc) {
 
 /* copy from golang rs version */
 static inline int code_some_shards(gf* matrixRows, gf** inputs, gf** outputs,
-        int dataShards, int outputCount, int byteCount) {
+                                   int dataShards, int outputCount,
+                                   int byteCount)
+{
     gf* in;
     int iRow, c;
     for(c = 0; c < dataShards; c++) {
@@ -678,7 +684,8 @@ static inline int code_some_shards(gf* matrixRows, gf** inputs, gf** outputs,
     return 0;
 }
 
-reed_solomon* reed_solomon_new(int data_shards, int parity_shards) {
+reed_solomon* reed_solomon_new(int data_shards, int parity_shards)
+{
     gf* vm = NULL;
     gf* top = NULL;
     int err = 0;
@@ -758,7 +765,8 @@ reed_solomon* reed_solomon_new(int data_shards, int parity_shards) {
     return NULL;
 }
 
-void reed_solomon_release(reed_solomon* rs) {
+void reed_solomon_release(reed_solomon* rs)
+{
     if(NULL != rs) {
         if(NULL != rs->m) {
             RS_FREE(rs->m);
@@ -778,13 +786,14 @@ void reed_solomon_release(reed_solomon* rs) {
  * fec_blocks[rs->data_shards][block_size]
  * */
 int reed_solomon_encode(reed_solomon* rs,
-        uint8_t** data_blocks,
-        uint8_t** fec_blocks,
-        int block_size) {
+                        uint8_t** data_blocks,
+                        uint8_t** fec_blocks,
+                        int block_size)
+{
     assert(NULL != rs && NULL != rs->parity);
 
-    return code_some_shards(rs->parity, data_blocks, fec_blocks
-            , rs->data_shards, rs->parity_shards, block_size);
+    return code_some_shards(rs->parity, data_blocks, fec_blocks,
+                            rs->data_shards, rs->parity_shards, block_size);
 }
 
 /**
@@ -798,12 +807,13 @@ int reed_solomon_encode(reed_solomon* rs,
  * nr_fec_blocks: the number of erased blocks
  * */
 int reed_solomon_decode(reed_solomon* rs,
-        uint8_t **data_blocks,
-        int block_size,
-        uint8_t **dec_fec_blocks,
-        unsigned int *fec_block_nos,
-        unsigned int *erased_blocks,
-        int nr_fec_blocks) {
+                        uint8_t **data_blocks,
+                        int block_size,
+                        uint8_t **dec_fec_blocks,
+                        unsigned int *fec_block_nos,
+                        unsigned int *erased_blocks,
+                        int nr_fec_blocks)
+{
     /* use stack instead of malloc, define a small number of DATA_SHARDS_MAX to save memory */
     gf dataDecodeMatrix[DATA_SHARDS_MAX*DATA_SHARDS_MAX];
     uint8_t* subShards[DATA_SHARDS_MAX];
@@ -897,7 +907,8 @@ int reed_solomon_decode(reed_solomon* rs,
  * shards[nr_shards][block_size]
  * */
 int reed_solomon_encode2(reed_solomon* rs, uint8_t** data_blocks,
-                         uint8_t** fec_blocks, int nr_shards, int block_size) {
+                         uint8_t** fec_blocks, int nr_shards, int block_size)
+{
     int i, ds = rs->data_shards, ps = rs->parity_shards, ss = rs->shards;
     i = nr_shards / ss;
 

--- a/src/rs.c
+++ b/src/rs.c
@@ -896,13 +896,10 @@ int reed_solomon_decode(reed_solomon* rs,
  * nr_shards: assert(0 == nr_shards % rs->shards)
  * shards[nr_shards][block_size]
  * */
-int reed_solomon_encode2(reed_solomon* rs, uint8_t** shards, int nr_shards, int block_size) {
-    uint8_t** data_blocks;
-    uint8_t** fec_blocks;
+int reed_solomon_encode2(reed_solomon* rs, uint8_t** data_blocks,
+                         uint8_t** fec_blocks, int nr_shards, int block_size) {
     int i, ds = rs->data_shards, ps = rs->parity_shards, ss = rs->shards;
     i = nr_shards / ss;
-    data_blocks = shards;
-    fec_blocks = &shards[(i*ds)];
 
     for(i = 0; i < nr_shards; i += ss) {
         reed_solomon_encode(rs, data_blocks, fec_blocks, block_size);
@@ -921,24 +918,23 @@ int reed_solomon_encode2(reed_solomon* rs, uint8_t** shards, int nr_shards, int 
  * marks[nr_shards] marks as errors
  * */
 int reed_solomon_reconstruct(reed_solomon* rs,
-        uint8_t** shards,
-        uint8_t* marks,
-        int nr_shards,
-        int block_size) {
+                             uint8_t** data_blocks,
+                             uint8_t** fec_blocks,
+                             uint8_t* marks,
+                             int nr_shards,
+                             int block_size)
+{
     uint8_t *dec_fec_blocks[DATA_SHARDS_MAX];
     unsigned int fec_block_nos[DATA_SHARDS_MAX];
     unsigned int erased_blocks[DATA_SHARDS_MAX];
     uint8_t* fec_marks;
-    uint8_t **data_blocks, **fec_blocks;
     int i, j, dn, pn, n;
     int ds = rs->data_shards;
     int ps = rs->parity_shards;
     int err = 0;
 
-    data_blocks = shards;
     n = nr_shards / rs->shards;
     fec_marks = marks + n*ds; //after all data, is't fec marks
-    fec_blocks = shards + n*ds;
 
     for(j = 0; j < n; j++) {
         dn = 0;

--- a/src/rs.c
+++ b/src/rs.c
@@ -44,11 +44,12 @@
  */
 #define GF_BITS  8  /* code over GF(2**GF_BITS) - change to suit */
 
+#include <assert.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include <assert.h>
 #include "rs.h"
 
 /*
@@ -90,7 +91,7 @@ u_long ticks[10];   /* vars for timekeeping */
  * gf is the type used to store an element of the Galois Field.
  * Must constain at least GF_BITS bits.
  *
- * Note: unsigned char will work up to GF(256) but int seems to run
+ * Note: uint8_t will work up to GF(256) but int seems to run
  * faster on the Pentium. We use int whenever have to deal with an
  * index, since they are generally faster.
  */
@@ -100,7 +101,7 @@ u_long ticks[10];   /* vars for timekeeping */
 #if (GF_BITS != 8)
 #error "GF_BITS must be 8"
 #endif
-typedef unsigned char gf;
+typedef uint8_t gf;
 
 #define GF_SIZE ((1 << GF_BITS) - 1)    /* powers of \alpha */
 
@@ -777,8 +778,8 @@ void reed_solomon_release(reed_solomon* rs) {
  * fec_blocks[rs->data_shards][block_size]
  * */
 int reed_solomon_encode(reed_solomon* rs,
-        unsigned char** data_blocks,
-        unsigned char** fec_blocks,
+        uint8_t** data_blocks,
+        uint8_t** fec_blocks,
         int block_size) {
     assert(NULL != rs && NULL != rs->parity);
 
@@ -797,16 +798,16 @@ int reed_solomon_encode(reed_solomon* rs,
  * nr_fec_blocks: the number of erased blocks
  * */
 int reed_solomon_decode(reed_solomon* rs,
-        unsigned char **data_blocks,
+        uint8_t **data_blocks,
         int block_size,
-        unsigned char **dec_fec_blocks,
+        uint8_t **dec_fec_blocks,
         unsigned int *fec_block_nos,
         unsigned int *erased_blocks,
         int nr_fec_blocks) {
     /* use stack instead of malloc, define a small number of DATA_SHARDS_MAX to save memory */
     gf dataDecodeMatrix[DATA_SHARDS_MAX*DATA_SHARDS_MAX];
-    unsigned char* subShards[DATA_SHARDS_MAX];
-    unsigned char* outputs[DATA_SHARDS_MAX];
+    uint8_t* subShards[DATA_SHARDS_MAX];
+    uint8_t* outputs[DATA_SHARDS_MAX];
     gf* m = rs->m;
     int i, j, c, swap, subMatrixRow, dataShards, nos, nshards;
 
@@ -895,9 +896,9 @@ int reed_solomon_decode(reed_solomon* rs,
  * nr_shards: assert(0 == nr_shards % rs->shards)
  * shards[nr_shards][block_size]
  * */
-int reed_solomon_encode2(reed_solomon* rs, unsigned char** shards, int nr_shards, int block_size) {
-    unsigned char** data_blocks;
-    unsigned char** fec_blocks;
+int reed_solomon_encode2(reed_solomon* rs, uint8_t** shards, int nr_shards, int block_size) {
+    uint8_t** data_blocks;
+    uint8_t** fec_blocks;
     int i, ds = rs->data_shards, ps = rs->parity_shards, ss = rs->shards;
     i = nr_shards / ss;
     data_blocks = shards;
@@ -920,15 +921,15 @@ int reed_solomon_encode2(reed_solomon* rs, unsigned char** shards, int nr_shards
  * marks[nr_shards] marks as errors
  * */
 int reed_solomon_reconstruct(reed_solomon* rs,
-        unsigned char** shards,
-        unsigned char* marks,
+        uint8_t** shards,
+        uint8_t* marks,
         int nr_shards,
         int block_size) {
-    unsigned char *dec_fec_blocks[DATA_SHARDS_MAX];
+    uint8_t *dec_fec_blocks[DATA_SHARDS_MAX];
     unsigned int fec_block_nos[DATA_SHARDS_MAX];
     unsigned int erased_blocks[DATA_SHARDS_MAX];
-    unsigned char* fec_marks;
-    unsigned char **data_blocks, **fec_blocks;
+    uint8_t* fec_marks;
+    uint8_t **data_blocks, **fec_blocks;
     int i, j, dn, pn, n;
     int ds = rs->data_shards;
     int ps = rs->parity_shards;
@@ -979,4 +980,3 @@ int reed_solomon_reconstruct(reed_solomon* rs,
 
     return err;
 }
-

--- a/src/rs.h
+++ b/src/rs.h
@@ -1,0 +1,88 @@
+#ifndef __RS_H_
+#define __RS_H_
+
+/* use small value to save memory */
+#ifndef DATA_SHARDS_MAX
+#define DATA_SHARDS_MAX (255)
+#endif
+
+/* use other memory allocator */
+#ifndef RS_MALLOC
+#define RS_MALLOC(x)    malloc(x)
+#endif
+
+#ifndef RS_FREE
+#define RS_FREE(x)      free(x)
+#endif
+
+#ifndef RS_CALLOC
+#define RS_CALLOC(n, x) calloc(n, x)
+#endif
+
+typedef struct _reed_solomon {
+    int data_shards;
+    int parity_shards;
+    int shards;
+    unsigned char* m;
+    unsigned char* parity;
+} reed_solomon;
+
+/**
+ * MUST initial one time
+ * */
+void fec_init(void);
+
+reed_solomon* reed_solomon_new(int data_shards, int parity_shards);
+void reed_solomon_release(reed_solomon* rs);
+
+/**
+ * encode one shard
+ * input:
+ * rs
+ * data_blocks[rs->data_shards][block_size]
+ * fec_blocks[rs->data_shards][block_size]
+ * */
+int reed_solomon_encode(reed_solomon* rs,
+        unsigned char** data_blocks,
+        unsigned char** fec_blocks,
+        int block_size);
+
+
+/**
+ * decode one shard
+ * input:
+ * rs
+ * original data_blocks[rs->data_shards][block_size]
+ * dec_fec_blocks[nr_fec_blocks][block_size]
+ * fec_block_nos: fec pos number in original fec_blocks
+ * erased_blocks: erased blocks in original data_blocks
+ * nr_fec_blocks: the number of erased blocks
+ * */
+int reed_solomon_decode(reed_solomon* rs,
+        unsigned char **data_blocks,
+        int block_size,
+        unsigned char **dec_fec_blocks,
+        unsigned int *fec_block_nos,
+        unsigned int *erased_blocks,
+        int nr_fec_blocks);
+
+/**
+ * encode a big size of buffer
+ * input:
+ * rs
+ * nr_shards: assert(0 == nr_shards % rs->data_shards)
+ * shards[nr_shards][block_size]
+ * */
+int reed_solomon_encode2(reed_solomon* rs, unsigned char** shards, int nr_shards, int block_size);
+
+/**
+ * reconstruct a big size of buffer
+ * input:
+ * rs
+ * nr_shards: assert(0 == nr_shards % rs->data_shards)
+ * shards[nr_shards][block_size]
+ * marks[nr_shards] marks as errors
+ * */
+int reed_solomon_reconstruct(reed_solomon* rs, unsigned char** shards, unsigned char* marks, int nr_shards, int block_size);
+#endif
+

--- a/src/rs.h
+++ b/src/rs.h
@@ -23,8 +23,8 @@ typedef struct _reed_solomon {
     int data_shards;
     int parity_shards;
     int shards;
-    unsigned char* m;
-    unsigned char* parity;
+    uint8_t* m;
+    uint8_t* parity;
 } reed_solomon;
 
 /**
@@ -43,8 +43,8 @@ void reed_solomon_release(reed_solomon* rs);
  * fec_blocks[rs->data_shards][block_size]
  * */
 int reed_solomon_encode(reed_solomon* rs,
-        unsigned char** data_blocks,
-        unsigned char** fec_blocks,
+        uint8_t** data_blocks,
+        uint8_t** fec_blocks,
         int block_size);
 
 
@@ -59,9 +59,9 @@ int reed_solomon_encode(reed_solomon* rs,
  * nr_fec_blocks: the number of erased blocks
  * */
 int reed_solomon_decode(reed_solomon* rs,
-        unsigned char **data_blocks,
+        uint8_t **data_blocks,
         int block_size,
-        unsigned char **dec_fec_blocks,
+        uint8_t **dec_fec_blocks,
         unsigned int *fec_block_nos,
         unsigned int *erased_blocks,
         int nr_fec_blocks);
@@ -73,7 +73,7 @@ int reed_solomon_decode(reed_solomon* rs,
  * nr_shards: assert(0 == nr_shards % rs->data_shards)
  * shards[nr_shards][block_size]
  * */
-int reed_solomon_encode2(reed_solomon* rs, unsigned char** shards, int nr_shards, int block_size);
+int reed_solomon_encode2(reed_solomon* rs, uint8_t** shards, int nr_shards, int block_size);
 
 /**
  * reconstruct a big size of buffer
@@ -83,6 +83,6 @@ int reed_solomon_encode2(reed_solomon* rs, unsigned char** shards, int nr_shards
  * shards[nr_shards][block_size]
  * marks[nr_shards] marks as errors
  * */
-int reed_solomon_reconstruct(reed_solomon* rs, unsigned char** shards, unsigned char* marks, int nr_shards, int block_size);
+int reed_solomon_reconstruct(reed_solomon* rs, uint8_t** shards, uint8_t* marks, int nr_shards, int block_size);
 #endif
 

--- a/src/rs.h
+++ b/src/rs.h
@@ -73,7 +73,8 @@ int reed_solomon_decode(reed_solomon* rs,
  * nr_shards: assert(0 == nr_shards % rs->data_shards)
  * shards[nr_shards][block_size]
  * */
-int reed_solomon_encode2(reed_solomon* rs, uint8_t** shards, int nr_shards, int block_size);
+int reed_solomon_encode2(reed_solomon* rs, uint8_t** data_blocks,
+                         uint8_t** fec_blocks, int nr_shards, int block_size);
 
 /**
  * reconstruct a big size of buffer
@@ -83,6 +84,7 @@ int reed_solomon_encode2(reed_solomon* rs, uint8_t** shards, int nr_shards, int 
  * shards[nr_shards][block_size]
  * marks[nr_shards] marks as errors
  * */
-int reed_solomon_reconstruct(reed_solomon* rs, uint8_t** shards, uint8_t* marks, int nr_shards, int block_size);
+int reed_solomon_reconstruct(reed_solomon* rs, uint8_t** data_blocks,
+                             uint8_t** fec_blocks, uint8_t* marks,
+                             int nr_shards, int block_size);
 #endif
-

--- a/src/rs.h
+++ b/src/rs.h
@@ -43,9 +43,9 @@ void reed_solomon_release(reed_solomon* rs);
  * fec_blocks[rs->data_shards][block_size]
  * */
 int reed_solomon_encode(reed_solomon* rs,
-        uint8_t** data_blocks,
-        uint8_t** fec_blocks,
-        int block_size);
+                        uint8_t** data_blocks,
+                        uint8_t** fec_blocks,
+                        int block_size);
 
 
 /**
@@ -59,12 +59,12 @@ int reed_solomon_encode(reed_solomon* rs,
  * nr_fec_blocks: the number of erased blocks
  * */
 int reed_solomon_decode(reed_solomon* rs,
-        uint8_t **data_blocks,
-        int block_size,
-        uint8_t **dec_fec_blocks,
-        unsigned int *fec_block_nos,
-        unsigned int *erased_blocks,
-        int nr_fec_blocks);
+                        uint8_t **data_blocks,
+                        int block_size,
+                        uint8_t **dec_fec_blocks,
+                        unsigned int *fec_block_nos,
+                        unsigned int *erased_blocks,
+                        int nr_fec_blocks);
 
 /**
  * encode a big size of buffer

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,8 +1,10 @@
-noinst_PROGRAMS = tests
+noinst_PROGRAMS = tests tests_rs
 tests_SOURCES = mockbridge.c mockfarmer.c tests.c storjtests.h $(top_builddir)/src/storj.h mockbridge.json.h mockbridgeinfo.json.h
 tests_LDADD = $(top_builddir)/src/libstorj.la
 tests_LDFLAGS = -Wall -g -static -lmicrohttpd
-TESTS = tests
+tests_rs_SOURCES = tests_rs.c
+tests_rs_LDFLAGS = -Wall -g
+TESTS = tests tests_rs
 
 CLEANFILES = mockbridge.json.h mockbridgeinfo.json.h
 

--- a/test/test_rs.c
+++ b/test/test_rs.c
@@ -1,0 +1,839 @@
+/**
+ * MIT License
+ * Copyright (c) 2016 janson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <string.h>
+#include <assert.h>
+#include <sys/time.h>
+#include <time.h>
+
+#define PROFILE
+#include "rs.h"
+#include "rs.c"
+
+void print_matrix1(gf* matrix, int nrows, int ncols);
+void print_matrix2(gf** matrix, int nrows, int ncols);
+
+void print_buf(gf* buf, char *fmt, size_t len) {
+    size_t i = 0;
+    while(i < len) {
+        printf(fmt, buf[i]);
+        i++;
+        if((i % 16) == 0) {
+            printf("\n");
+        }
+    }
+    printf("\n");
+}
+
+void test_galois(void) {
+    printf("%s:\n", __FUNCTION__);
+
+    //copy from golang rs version
+    assert(galMultiply(3, 4) == 12);
+    assert(galMultiply(7, 7) == 21);
+    assert(galMultiply(23, 45) == 41);
+
+    {
+        gf in[] = {0, 1, 2, 3, 4, 5, 6, 10, 50, 100, 150, 174, 201, 255, 99, 32, 67, 85};
+        gf out[sizeof(in)/sizeof(gf)] = {0};
+        gf expect[] = {0x0, 0x19, 0x32, 0x2b, 0x64, 0x7d, 0x56, 0xfa, 0xb8, 0x6d, 0xc7, 0x85, 0xc3, 0x1f, 0x22, 0x7, 0x25, 0xfe};
+        gf expect2[] = {0x0, 0xb1, 0x7f, 0xce, 0xfe, 0x4f, 0x81, 0x9e, 0x3, 0x6, 0xe8, 0x75, 0xbd, 0x40, 0x36, 0xa3, 0x95, 0xcb};
+        int rlt;
+        addmul(out, in, 25, sizeof(int)/sizeof(gf));
+        rlt = memcmp(out, expect, sizeof(int)/sizeof(gf));
+        assert(0 == rlt);
+
+        memset(out, 0, sizeof(in)/sizeof(gf));
+        addmul(out, in, 177, sizeof(in)/sizeof(gf));
+        rlt = memcmp(out, expect2, sizeof(int)/sizeof(gf));
+        assert(0 == rlt);
+    }
+
+    assert(galExp(2,2) == 4);
+    assert(galExp(5,20) == 235);
+    assert(galExp(13,7) == 43);
+}
+
+void test_sub_matrix(void) {
+    int r, c, ptr, nrows = 10, ncols = 20;
+    gf* m1 = (gf*)RS_MALLOC(nrows * ncols);
+    gf *test1;
+
+    printf("%s:\n", __FUNCTION__);
+
+    ptr = 0;
+    for(r = 0; r < nrows; r++) {
+        for(c = 0; c < ncols; c++) {
+            m1[ptr] = ptr;
+            ptr++;
+        }
+    }
+    test1 = sub_matrix(m1, 0, 0, 3, 4, nrows, ncols);
+    for(r = 0; r < 3; r++) {
+        for(c = 0; c < 4; c++) {
+            assert(test1[r*4 + c] == (r*ncols + c));
+        }
+    }
+    free(test1);
+
+    test1 = sub_matrix(m1, 3, 2, 7, 9, nrows, ncols);
+    for(r = 0; r < (7-3); r++) {
+        for(c = 0; c < (9-2); c++) {
+            assert(test1[r*(9-2) + c] == ((r+3)*ncols + (c+2)));
+        }
+    }
+
+    free(m1);
+}
+
+void test_multiply(void) {
+    gf a[] = {1,2,3,4};
+    gf b[] = {5,6,7,8};
+    gf exp[] = {11,22,19,42};
+    gf *out;
+    int rlt;
+
+    printf("%s:\n", __FUNCTION__);
+
+    out = multiply1(a, 2, 2, b, 2, 2);
+    rlt = memcmp(out, exp, 4);
+    assert(0 == rlt);
+}
+
+void test_inverse(void) {
+    printf("%s:\n", __FUNCTION__);
+    {
+        gf a[] = {56, 23, 98, 3, 100, 200, 45, 201, 123};
+        gf ae[] = {175, 133, 33, 130, 13, 245, 112, 35, 126};
+        int rlt = invert_mat(a, 3);
+        assert(0 == rlt);
+        rlt = memcmp(a, ae, 3*3);
+        assert(0 == rlt);
+    }
+
+    {
+        gf a[] = {  1, 0, 0, 0, 0,
+                    0, 1, 0, 0, 0,
+                    0, 0, 0, 1, 0,
+                    0, 0, 0, 0, 1,
+                    7, 7, 6, 6, 1};
+        gf ae[] = {1, 0, 0, 0, 0,
+                   0, 1, 0, 0, 0,
+                   123, 123, 1, 122, 122,
+                   0, 0, 1, 0, 0,
+                   0, 0, 0, 1, 0};
+        int rlt = invert_mat(a, 5);
+        assert(0 == rlt);
+        rlt = memcmp(a, ae, 5*5);
+        assert(0 == rlt);
+    }
+
+    {
+        /* error matrix */
+        gf a[] = {4,2,12,6};
+        int rlt = invert_mat(a, 2);
+        assert(0 != rlt);
+    }
+}
+
+unsigned char* test_create_random(reed_solomon *rs, int data_size, int block_size) {
+    struct timeval tv;
+    unsigned char* data;
+    int i, n, seed, nr_blocks;
+
+    gettimeofday(&tv, 0);
+    seed = tv.tv_sec ^ tv.tv_usec;
+    srandom(seed);
+
+    nr_blocks = (data_size+block_size-1)/block_size;
+    nr_blocks = ((nr_blocks + rs->data_shards - 1)/ rs->data_shards) * rs->data_shards;
+    n = nr_blocks / rs->data_shards;
+    nr_blocks += n * rs->parity_shards;
+
+    data = malloc(nr_blocks * block_size);
+    for(i = 0; i < data_size; i++) {
+        data[i] = (unsigned char)(random() % 255);
+    }
+    memset(data + data_size, 0, nr_blocks*block_size - data_size);
+
+    return data;
+}
+
+int test_create_encoding(
+        reed_solomon *rs,
+        unsigned char *data,
+        int data_size,
+        int block_size
+        ) {
+    unsigned char **data_blocks;
+    int data_shards, parity_shards;
+    int i, n, nr_shards, nr_blocks, nr_fec_blocks;
+
+    data_shards = rs->data_shards;
+    parity_shards = rs->parity_shards;
+    nr_blocks = (data_size+block_size-1)/block_size;
+    nr_blocks = ((nr_blocks+data_shards-1)/data_shards) * data_shards;
+    n = nr_blocks / data_shards;
+    nr_fec_blocks = n * parity_shards;
+    nr_shards = nr_blocks + nr_fec_blocks;
+
+    data_blocks = (unsigned char**)malloc(nr_shards * sizeof(unsigned char*));
+    for(i = 0; i < nr_shards; i++) {
+        data_blocks[i] = data + i*block_size;
+    }
+
+    n = reed_solomon_encode2(rs, data_blocks, nr_shards, block_size);
+    free(data_blocks);
+
+    return n;
+}
+
+int test_data_decode(
+        reed_solomon *rs,
+        unsigned char *data,
+        int data_size,
+        int block_size,
+        int *erases,
+        int erase_count) {
+    unsigned char **data_blocks;
+    unsigned char *zilch;
+    int data_shards, parity_shards;
+    int i, j, n, nr_shards, nr_blocks, nr_fec_blocks;
+
+    data_shards = rs->data_shards;
+    parity_shards = rs->parity_shards;
+    nr_blocks = (data_size+block_size-1)/block_size;
+    nr_blocks = ((nr_blocks+data_shards-1)/data_shards) * data_shards;
+    n = nr_blocks / data_shards;
+    nr_fec_blocks = n * parity_shards;
+    nr_shards = nr_blocks + nr_fec_blocks;
+
+    data_blocks = (unsigned char**)malloc(nr_shards * sizeof(unsigned char*));
+    for(i = 0; i < nr_shards; i++) {
+        data_blocks[i] = data + i*block_size;
+    }
+
+    zilch = (unsigned char*)calloc(1, nr_shards);
+    for(i = 0; i < erase_count; i++) {
+        j = erases[i];
+        memset(data + j*block_size, 137, block_size);
+        zilch[j] = 1; //mark as erased
+    }
+
+    n = reed_solomon_reconstruct(rs, data_blocks, zilch, nr_shards, block_size);
+    free(data_blocks);
+    free(zilch);
+
+    return n;
+}
+
+void test_one_encoding(void) {
+    reed_solomon *rs;
+    unsigned char* data;
+    int block_size = 50000;
+    int data_size = 10*block_size;
+    int err;
+
+    printf("%s:\n", __FUNCTION__);
+
+    rs = reed_solomon_new(10, 3);
+    data = test_create_random(rs, data_size, block_size);
+    err = test_create_encoding(rs, data, data_size, block_size);
+
+    free(data);
+    reed_solomon_release(rs);
+
+    assert(0 == err);
+}
+
+int test_one_decoding_13(int *erases, int erase_count) {
+    reed_solomon *rs;
+    unsigned char *data, *origin;
+    int block_size = 50000;
+    int data_size = 10*block_size;
+    int err, err2;
+
+    rs = reed_solomon_new(10, 3);
+    data = test_create_random(rs, data_size, block_size);
+    err = test_create_encoding(rs, data, data_size, block_size);
+    assert(0 == err);
+
+    origin = (unsigned char*)malloc(data_size);
+    memcpy(origin, data, data_size);
+
+    err = test_data_decode(rs, data, data_size, block_size, erases, erase_count);
+    if(0 == err) {
+        err2 = memcmp(origin, data, data_size);
+        assert(0 == err2);
+    } else {
+        //failed here
+        err2 = memcmp(origin, data, data_size);
+        assert(0 != err2);
+    }
+
+    free(data);
+    free(origin);
+    reed_solomon_release(rs);
+
+    return err;
+}
+
+void test_one_decoding(void) {
+    printf("%s:\n", __FUNCTION__);
+
+    {
+        int erases[] = {0};
+        int err;
+
+        // lost nothing
+        err = test_one_decoding_13(erases, 0);
+        assert(0 == err);
+    }
+
+    {
+        int erases[] = {0};
+        int erases_count = sizeof(erases)/sizeof(int);
+        int err;
+
+        // lost only one
+        err = test_one_decoding_13(erases, erases_count);
+        assert(0 == err);
+
+        erases[0] = 5;
+        err = test_one_decoding_13(erases, erases_count);
+        assert(0 == err);
+
+        erases[0] = 9;
+        err = test_one_decoding_13(erases, erases_count);
+        assert(0 == err);
+
+        erases[0] = 11;
+        err = test_one_decoding_13(erases, erases_count);
+        assert(0 == err);
+    }
+
+    {
+        int erases[] = {0, 1};
+        int erases_count = sizeof(erases)/sizeof(int);
+        int err;
+
+        // lost two
+        err = test_one_decoding_13(erases, erases_count);
+        assert(0 == err);
+
+        erases[0] = 3;
+        erases[1] = 7;
+        err = test_one_decoding_13(erases, erases_count);
+        assert(0 == err);
+
+        erases[0] = 11;
+        erases[1] = 9;
+        err = test_one_decoding_13(erases, erases_count);
+        assert(0 == err);
+
+        erases[0] = 11;
+        erases[1] = 12;
+        err = test_one_decoding_13(erases, erases_count);
+        assert(0 == err);
+    }
+
+    {
+        int erases[] = {0, 1, 4};
+        int erases_count = sizeof(erases)/sizeof(int);
+        int err;
+
+        // lost three
+        err = test_one_decoding_13(erases, erases_count);
+        assert(0 == err);
+
+        erases[0] = 3;
+        erases[1] = 8;
+        erases[2] = 7;
+        err = test_one_decoding_13(erases, erases_count);
+        assert(0 == err);
+
+        erases[0] = 11;
+        erases[1] = 9;
+        erases[2] = 1;
+        err = test_one_decoding_13(erases, erases_count);
+        assert(0 == err);
+
+        erases[0] = 11;
+        erases[1] = 12;
+        erases[2] = 9;
+        err = test_one_decoding_13(erases, erases_count);
+        assert(0 == err);
+
+        erases[0] = 11;
+        erases[1] = 12;
+        erases[2] = 9;
+        err = test_one_decoding_13(erases, erases_count);
+        assert(0 == err);
+
+        erases[0] = 11;
+        erases[1] = 12;
+        erases[2] = 10;
+        err = test_one_decoding_13(erases, erases_count);
+        assert(0 == err);
+    }
+
+    {
+        int erases[] = {0, 1, 4, 8};
+        int erases_count = sizeof(erases)/sizeof(int);
+        int err;
+
+        // lost 4, failed!
+        err = test_one_decoding_13(erases, erases_count);
+        assert(0 != err);
+
+        erases[0] = 11;
+        erases[1] = 12;
+        erases[2] = 10;
+        erases[3] = 9;
+        err = test_one_decoding_13(erases, erases_count);
+        assert(0 != err);
+    }
+}
+
+int test_one_decoding_13_6(int *erases, int erase_count) {
+    reed_solomon *rs;
+    unsigned char *data, *origin;
+    int block_size = 50000;
+    int data_size = 10*block_size*6;
+    int err, err2;
+
+    rs = reed_solomon_new(10, 3);
+    data = test_create_random(rs, data_size, block_size);
+    err = test_create_encoding(rs, data, data_size, block_size);
+    assert(0 == err);
+
+    origin = (unsigned char*)malloc(data_size);
+    memcpy(origin, data, data_size);
+
+    err = test_data_decode(rs, data, data_size, block_size, erases, erase_count);
+    if(0 == err) {
+        err2 = memcmp(origin, data, data_size);
+        assert(0 == err2);
+    } else {
+        //failed here
+        err2 = memcmp(origin, data, data_size);
+        assert(0 != err2);
+    }
+
+    free(data);
+    free(origin);
+    reed_solomon_release(rs);
+
+    return err;
+}
+
+void test_encoding(void) {
+    reed_solomon *rs;
+    unsigned char *data;
+    int block_size = 50000;
+    //multi shards encoding
+    int data_size = 13*block_size*6;
+    int err;
+
+    printf("%s:\n", __FUNCTION__);
+
+    rs = reed_solomon_new(10, 3);
+    data = test_create_random(rs, data_size, block_size);
+    err = test_create_encoding(rs, data, data_size, block_size);
+
+    free(data);
+    reed_solomon_release(rs);
+
+    assert(0 == err);
+}
+
+void test_reconstruct(void) {
+#define FEC_START (10*6)
+    printf("%s:\n", __FUNCTION__);
+
+    {
+        int erases[] = {0};
+        int err;
+
+        // lost nothing
+        err = test_one_decoding_13_6(erases, 0);
+        assert(0 == err);
+    }
+
+    {
+        int erases[] = {0, 1, 9, 10+2, 10+4, 10+9};
+        int erases_count = sizeof(erases)/sizeof(int);
+        int err;
+
+        // shard1 shard2 both lost three
+        err = test_one_decoding_13_6(erases, erases_count);
+        assert(0 == err);
+    }
+
+    {
+        int erases[] = {0, 9, FEC_START + 1, 10+2, 10+9, FEC_START + 3 + 2};
+        int erases_count = sizeof(erases)/sizeof(int);
+        int err;
+
+        // shard1 shard2 both lost three, and both lost one in fec
+        err = test_one_decoding_13_6(erases, erases_count);
+        assert(0 == err);
+    }
+
+    {
+        int erases[] = {11, 12, 10, 9};
+        int erases_count = sizeof(erases)/sizeof(int);
+        int err;
+
+        /* this is ok. not lost 4 but shard1 lost 1, shard2 lost 3, we can reconstruct it */
+        err = test_one_decoding_13_6(erases, erases_count);
+        assert(0 == err);
+    }
+
+    {
+        int erases[] = {0, 1, 4, 8};
+        int erases_count = sizeof(erases)/sizeof(int);
+        int err;
+
+        // shard1 lost 4, failed!
+        err = test_one_decoding_13_6(erases, erases_count);
+        assert(0 != err);
+    }
+
+    {
+        int erases[] = {10, 11, 14, 18};
+        int erases_count = sizeof(erases)/sizeof(int);
+        int err;
+
+        // shard2 lost 4, failed!
+        err = test_one_decoding_13_6(erases, erases_count);
+        assert(0 != err);
+    }
+
+    {
+        int erases[] = {0, 1, 4, 8, 10, 11, 14, 18};
+        int erases_count = sizeof(erases)/sizeof(int);
+        int err;
+
+        // shard1 and shard2 both lost 4, failed!
+        err = test_one_decoding_13_6(erases, erases_count);
+        assert(0 != err);
+    }
+
+    {
+        int erases[] = {11, 12, 10, 9, FEC_START+3+0, FEC_START+3+1, FEC_START+3+2};
+        int erases_count = sizeof(erases)/sizeof(int);
+        int err;
+
+        err = test_one_decoding_13_6(erases, erases_count);
+        assert(0 != err);
+    }
+}
+
+double benchmarkEncodeTest(int n, int dataShards, int parityShards, int shardSize) {
+    clock_t start, end;
+    double millis;
+    unsigned char* data;
+    int i;
+    int dataSize = shardSize*dataShards;
+    reed_solomon* rs = reed_solomon_new(dataShards, parityShards);
+
+    data = test_create_random(rs, dataSize, shardSize);
+
+    start = clock();
+    for(i = 0; i < n; i++) {
+        test_create_encoding(rs, data, dataSize, shardSize);
+    }
+    end = clock();
+    millis = (double)(end - start) * 1000.0 / CLOCKS_PER_SEC;
+    return (millis);
+}
+
+/* TODO please check, is this benchmark ok? */
+void benchmarkEncode(void) {
+    double millis;
+    double per_sec_in_bytes;
+    double MB = 1024.0 * 1024.0;
+    double millis_to_sec = 1000*1000;
+    int n;
+    int size;
+
+    printf("%s:\n", __FUNCTION__);
+
+    n = 20000;
+    size = 10000;
+    millis = benchmarkEncodeTest(n, 10, 2, size);
+
+    per_sec_in_bytes = (10*2*size/MB) * millis_to_sec * n / millis;
+    printf("10x2x10000, test_count=%d millis=%lf per_sec_in_bytes=%lfMB/s\n", n, millis, per_sec_in_bytes);
+
+    n = 200;
+    millis = benchmarkEncodeTest(n, 100, 20, size);
+    per_sec_in_bytes = (100*20*size/MB) * millis_to_sec * n / millis;
+    printf("100x20x10000, test_count=%d millis=%lf per_sec_in_bytes=%lfMB/s\n", n, millis, per_sec_in_bytes);
+
+    n = 200;
+    size = 1024*1024;
+    millis = benchmarkEncodeTest(n, 17, 3, size);
+    per_sec_in_bytes = (17*3*size/MB) * millis_to_sec * n / millis;
+    printf("17x3x(1024*1024), test_count=%d millis=%lf per_sec_in_bytes=%lfMB/s\n", n, millis, per_sec_in_bytes);
+}
+
+void test_001(void) {
+    reed_solomon* rs = reed_solomon_new(11, 6);
+    print_matrix1(rs->m, rs->data_shards, rs->data_shards);
+    print_matrix1(rs->parity, rs->parity_shards, rs->data_shards);
+    reed_solomon_release(rs);
+}
+
+void test_002(void) {
+    char text[] = "hello world", output[256];
+    int block_size = 1;
+    int nrDataBlocks = sizeof(text)/sizeof(char) - 1;
+    unsigned char* data_blocks[128];
+    unsigned char* fec_blocks[128];
+    int nrFecBlocks = 6;
+
+    //decode
+    unsigned int fec_block_nos[128], erased_blocks[128];
+    unsigned char* dec_fec_blocks[128];
+    int nr_fec_blocks;
+
+    int i;
+    reed_solomon* rs = reed_solomon_new(nrDataBlocks, nrFecBlocks);
+
+    printf("%s:\n", __FUNCTION__);
+
+    for(i = 0; i < nrDataBlocks; i++) {
+        data_blocks[i] = (unsigned char*)&text[i];
+    }
+
+    memset(output, 0, sizeof(output));
+    memcpy(output, text, nrDataBlocks);
+    for(i = 0; i < nrFecBlocks; i++) {
+        fec_blocks[i] = (unsigned char*)&output[i + nrDataBlocks];
+    }
+
+    reed_solomon_encode(rs, data_blocks, fec_blocks, block_size);
+    print_buf((gf*)output, "%d ", nrFecBlocks+nrDataBlocks);
+
+    text[1] = 'x';
+    text[3] = 'y';
+    text[4] = 'z';
+    erased_blocks[0] = 4;
+    erased_blocks[1] = 1;
+    erased_blocks[2] = 3;
+
+    fec_block_nos[0] = 1;
+    fec_block_nos[1] = 3;
+    fec_block_nos[2] = 5;
+    dec_fec_blocks[0] = fec_blocks[1];
+    dec_fec_blocks[1] = fec_blocks[3];
+    dec_fec_blocks[2] = fec_blocks[5];
+    nr_fec_blocks = 3;
+
+    printf("erased:%s\n", text);
+
+    reed_solomon_decode(rs, data_blocks, block_size, dec_fec_blocks,
+            fec_block_nos, erased_blocks, nr_fec_blocks);
+
+    printf("fixed:%s\n", text);
+
+    reed_solomon_release(rs);
+}
+
+void test_003(void) {
+    char text[] = "hello world hello world ", output[256];
+    int block_size = 2;
+    int nrDataBlocks = (sizeof(text)/sizeof(char) - 1) / block_size;
+    unsigned char* data_blocks[128];
+    unsigned char* fec_blocks[128];
+    int nrFecBlocks = 6;
+
+    //decode
+    unsigned int fec_block_nos[128], erased_blocks[128];
+    unsigned char* dec_fec_blocks[128];
+    int nr_fec_blocks;
+
+    int i;
+    reed_solomon* rs = reed_solomon_new(nrDataBlocks, nrFecBlocks);
+
+    printf("%s:\n", __FUNCTION__);
+    //printf("text size=%d\n", (int)(sizeof(text)/sizeof(char) - 1) );
+
+    for(i = 0; i < nrDataBlocks; i++) {
+        data_blocks[i] = (unsigned char*)&text[i*block_size];
+    }
+
+    memset(output, 0, sizeof(output));
+    memcpy(output, text, nrDataBlocks*block_size);
+    //print_matrix1((gf*)output, nrDataBlocks + nrFecBlocks, block_size);
+    for(i = 0; i < nrFecBlocks; i++) {
+        fec_blocks[i] = (unsigned char*)&output[i*block_size + nrDataBlocks*block_size];
+    }
+    reed_solomon_encode(rs, data_blocks, fec_blocks, block_size);
+    printf("golang output(example/test_rs.go):\n [[104 101] [108 108] [111 32] [119 111] [114 108] [100 32] [104 101] [108 108] [111 32] [119 111] [114 108] [100 32] \n[157 178] [83 31] [48 240] [254 93] [31 89] [151 184]]\n");
+    printf("c verion output:\n");
+    print_buf((gf*)output, "%d ", nrFecBlocks*block_size + nrDataBlocks*block_size);
+    //print_matrix1((gf*)output, nrDataBlocks + nrFecBlocks, block_size);
+
+    //decode
+    text[1*block_size] = 'x';
+    text[10*block_size+1] = 'y';
+    text[4*block_size] = 'z';
+    erased_blocks[0] = 4;
+    erased_blocks[1] = 1;
+    erased_blocks[2] = 10;
+
+    fec_block_nos[0] = 1;
+    fec_block_nos[1] = 3;
+    fec_block_nos[2] = 5;
+    dec_fec_blocks[0] = fec_blocks[1];
+    dec_fec_blocks[1] = fec_blocks[3];
+    dec_fec_blocks[2] = fec_blocks[5];
+    nr_fec_blocks = 3;
+
+    printf("erased:%s\n", text);
+
+    reed_solomon_decode(rs, data_blocks, block_size, dec_fec_blocks,
+            fec_block_nos, erased_blocks, nr_fec_blocks);
+
+    printf("fixed:%s\n", text);
+
+    reed_solomon_release(rs);
+}
+
+void test_004(void) {
+    //char text[] = "hello world hello world ";
+    int dataShards = 30;
+    int parityShards = 21;
+    int blockSize = 280;
+    struct timeval tv;
+    int i, j, n, seed, size, nrShards, nrBlocks, nrFecBlocks;
+    unsigned char *origin, *data;
+    unsigned char **data_blocks;
+    unsigned char *zilch;
+    reed_solomon *rs;
+
+    gettimeofday(&tv, 0);
+    seed = tv.tv_sec ^ tv.tv_usec;
+    srandom(seed);
+
+    fec_init();
+
+    //size = sizeof(text)/sizeof(char)-1;
+    size = 1024*1024;
+    origin = malloc(size);
+    //memcpy(origin, text, size);
+    for(i = 0; i < size; i++) {
+        origin[i] = (unsigned char)(random() % 255);
+    }
+
+    nrBlocks = (size+blockSize-1) / blockSize;
+    nrBlocks = ((nrBlocks+dataShards-1)/dataShards) * dataShards;
+    n = nrBlocks / dataShards;
+    nrFecBlocks = n*parityShards;
+    nrShards = nrBlocks + nrFecBlocks;
+    data = malloc(nrShards * blockSize);
+    memcpy(data, origin, size);
+    memset(data + size, 0, nrShards*blockSize - size);
+    printf("nrBlocks=%d nrFecBlocks=%d nrShards=%d n=%d left=%d\n", nrBlocks, nrFecBlocks, nrShards, n, nrShards*blockSize - size);
+    //print_buf(origin, "%d ", size);
+    //print_buf(data, "%d ", nrShards*blockSize);
+
+    data_blocks = (unsigned char**)malloc( nrShards * sizeof(unsigned char**) );
+    for(i = 0; i < nrShards; i++) {
+        data_blocks[i] = data + i*blockSize;
+    }
+
+    rs = reed_solomon_new(dataShards, parityShards);
+    reed_solomon_encode2(rs, data_blocks, nrShards, blockSize);
+    i = memcmp(origin, data, size);
+    assert(0 == i);
+    //print_matrix2(data_blocks, nrShards, blockSize);
+
+    zilch = (unsigned char*)calloc(1, nrShards);
+    n = parityShards;
+
+    /* int es[100];
+    es[0] = 3;
+    es[1] = 3;
+    es[2] = 2;
+    es[3] = 8; */
+
+    for(i = 0; i < n-2; i++) {
+        j = random() % (nrBlocks-1);
+        //j = es[i];
+        memset(data + j*blockSize, 137, blockSize);
+        zilch[j] = 1; //erased!
+        printf("erased %d\n", j);
+    }
+    if(nrFecBlocks > 2) {
+        for(i = 0; i < 2; i++) {
+            j = nrBlocks + (random() % nrFecBlocks);
+            memset(data + j*blockSize, 139, blockSize);
+            zilch[j] = 1;
+            printf("erased %d\n", j);
+        }
+    }
+
+    reed_solomon_reconstruct(rs, data_blocks, zilch, nrShards, blockSize);
+    i = memcmp(origin, data, size);
+    //print_buf(origin, "%d ", nrBlocks);
+    //print_buf(data, "%d ", nrBlocks);
+    printf("rlt=%d\n", i);
+    assert(0 == i);
+
+    free(origin);
+    free(data);
+    free(data_blocks);
+    free(zilch);
+    reed_solomon_release(rs);
+}
+
+int main(void) {
+    fec_init();
+
+    test_galois();
+    test_sub_matrix();
+    test_multiply();
+    test_inverse();
+    test_one_encoding();
+    test_one_decoding();
+    test_encoding();
+    test_reconstruct();
+    printf("reach here means test all ok\n");
+
+    benchmarkEncode();
+
+    //test_001();
+    //test_002();
+    test_003();
+    //test_004();
+
+    return 0;
+}

--- a/test/tests_rs.c
+++ b/test/tests_rs.c
@@ -31,8 +31,8 @@
 #include <time.h>
 
 #define PROFILE
-#include "rs.h"
-#include "rs.c"
+#include "../src/rs.h"
+#include "../src/rs.c"
 
 void print_matrix1(gf* matrix, int nrows, int ncols);
 void print_matrix2(gf** matrix, int nrows, int ncols);

--- a/test/tests_rs.c
+++ b/test/tests_rs.c
@@ -168,7 +168,7 @@ uint8_t* test_create_random(reed_solomon *rs, int data_size, int block_size) {
 
     gettimeofday(&tv, 0);
     seed = tv.tv_sec ^ tv.tv_usec;
-    srandom(seed);
+    srand(seed);
 
     nr_blocks = (data_size+block_size-1)/block_size;
     nr_blocks = ((nr_blocks + rs->data_shards - 1)/ rs->data_shards) * rs->data_shards;
@@ -177,7 +177,7 @@ uint8_t* test_create_random(reed_solomon *rs, int data_size, int block_size) {
 
     data = malloc(nr_blocks * block_size);
     for(i = 0; i < data_size; i++) {
-        data[i] = (uint8_t)(random() % 255);
+        data[i] = (uint8_t)(rand() % 255);
     }
     memset(data + data_size, 0, nr_blocks*block_size - data_size);
 
@@ -757,7 +757,7 @@ void test_004(void) {
 
     gettimeofday(&tv, 0);
     seed = tv.tv_sec ^ tv.tv_usec;
-    srandom(seed);
+    srand(seed);
 
     fec_init();
 
@@ -766,7 +766,7 @@ void test_004(void) {
     origin = malloc(size);
     //memcpy(origin, text, size);
     for(i = 0; i < size; i++) {
-        origin[i] = (uint8_t)(random() % 255);
+        origin[i] = (uint8_t)(rand() % 255);
     }
 
     nrBlocks = (size+blockSize-1) / blockSize;
@@ -807,7 +807,7 @@ void test_004(void) {
     es[3] = 8; */
 
     for(i = 0; i < n-2; i++) {
-        j = random() % (nrBlocks-1);
+        j = rand() % (nrBlocks-1);
         //j = es[i];
         memset(data + j*blockSize, 137, blockSize);
         zilch[j] = 1; //erased!
@@ -815,7 +815,7 @@ void test_004(void) {
     }
     if(nrFecBlocks > 2) {
         for(i = 0; i < 2; i++) {
-            j = nrBlocks + (random() % nrFecBlocks);
+            j = nrBlocks + (rand() % nrFecBlocks);
             memset(data + j*blockSize, 139, blockSize);
             zilch[j] = 1;
             printf("erased %d\n", j);

--- a/test/tests_rs.c
+++ b/test/tests_rs.c
@@ -21,14 +21,15 @@
  * SOFTWARE.
  */
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#include <string.h>
 #include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
 #include <sys/time.h>
 #include <time.h>
+#include <unistd.h>
 
 #define PROFILE
 #include "../src/rs.h"
@@ -160,9 +161,9 @@ void test_inverse(void) {
     }
 }
 
-unsigned char* test_create_random(reed_solomon *rs, int data_size, int block_size) {
+uint8_t* test_create_random(reed_solomon *rs, int data_size, int block_size) {
     struct timeval tv;
-    unsigned char* data;
+    uint8_t* data;
     int i, n, seed, nr_blocks;
 
     gettimeofday(&tv, 0);
@@ -176,7 +177,7 @@ unsigned char* test_create_random(reed_solomon *rs, int data_size, int block_siz
 
     data = malloc(nr_blocks * block_size);
     for(i = 0; i < data_size; i++) {
-        data[i] = (unsigned char)(random() % 255);
+        data[i] = (uint8_t)(random() % 255);
     }
     memset(data + data_size, 0, nr_blocks*block_size - data_size);
 
@@ -185,11 +186,11 @@ unsigned char* test_create_random(reed_solomon *rs, int data_size, int block_siz
 
 int test_create_encoding(
         reed_solomon *rs,
-        unsigned char *data,
+        uint8_t *data,
         int data_size,
         int block_size
         ) {
-    unsigned char **data_blocks;
+    uint8_t **data_blocks;
     int data_shards, parity_shards;
     int i, n, nr_shards, nr_blocks, nr_fec_blocks;
 
@@ -201,7 +202,7 @@ int test_create_encoding(
     nr_fec_blocks = n * parity_shards;
     nr_shards = nr_blocks + nr_fec_blocks;
 
-    data_blocks = (unsigned char**)malloc(nr_shards * sizeof(unsigned char*));
+    data_blocks = (uint8_t**)malloc(nr_shards * sizeof(uint8_t*));
     for(i = 0; i < nr_shards; i++) {
         data_blocks[i] = data + i*block_size;
     }
@@ -214,13 +215,13 @@ int test_create_encoding(
 
 int test_data_decode(
         reed_solomon *rs,
-        unsigned char *data,
+        uint8_t *data,
         int data_size,
         int block_size,
         int *erases,
         int erase_count) {
-    unsigned char **data_blocks;
-    unsigned char *zilch;
+    uint8_t **data_blocks;
+    uint8_t *zilch;
     int data_shards, parity_shards;
     int i, j, n, nr_shards, nr_blocks, nr_fec_blocks;
 
@@ -232,12 +233,12 @@ int test_data_decode(
     nr_fec_blocks = n * parity_shards;
     nr_shards = nr_blocks + nr_fec_blocks;
 
-    data_blocks = (unsigned char**)malloc(nr_shards * sizeof(unsigned char*));
+    data_blocks = (uint8_t**)malloc(nr_shards * sizeof(uint8_t*));
     for(i = 0; i < nr_shards; i++) {
         data_blocks[i] = data + i*block_size;
     }
 
-    zilch = (unsigned char*)calloc(1, nr_shards);
+    zilch = (uint8_t*)calloc(1, nr_shards);
     for(i = 0; i < erase_count; i++) {
         j = erases[i];
         memset(data + j*block_size, 137, block_size);
@@ -253,7 +254,7 @@ int test_data_decode(
 
 void test_one_encoding(void) {
     reed_solomon *rs;
-    unsigned char* data;
+    uint8_t* data;
     int block_size = 50000;
     int data_size = 10*block_size;
     int err;
@@ -272,7 +273,7 @@ void test_one_encoding(void) {
 
 int test_one_decoding_13(int *erases, int erase_count) {
     reed_solomon *rs;
-    unsigned char *data, *origin;
+    uint8_t *data, *origin;
     int block_size = 50000;
     int data_size = 10*block_size;
     int err, err2;
@@ -282,7 +283,7 @@ int test_one_decoding_13(int *erases, int erase_count) {
     err = test_create_encoding(rs, data, data_size, block_size);
     assert(0 == err);
 
-    origin = (unsigned char*)malloc(data_size);
+    origin = (uint8_t*)malloc(data_size);
     memcpy(origin, data, data_size);
 
     err = test_data_decode(rs, data, data_size, block_size, erases, erase_count);
@@ -421,7 +422,7 @@ void test_one_decoding(void) {
 
 int test_one_decoding_13_6(int *erases, int erase_count) {
     reed_solomon *rs;
-    unsigned char *data, *origin;
+    uint8_t *data, *origin;
     int block_size = 50000;
     int data_size = 10*block_size*6;
     int err, err2;
@@ -431,7 +432,7 @@ int test_one_decoding_13_6(int *erases, int erase_count) {
     err = test_create_encoding(rs, data, data_size, block_size);
     assert(0 == err);
 
-    origin = (unsigned char*)malloc(data_size);
+    origin = (uint8_t*)malloc(data_size);
     memcpy(origin, data, data_size);
 
     err = test_data_decode(rs, data, data_size, block_size, erases, erase_count);
@@ -453,7 +454,7 @@ int test_one_decoding_13_6(int *erases, int erase_count) {
 
 void test_encoding(void) {
     reed_solomon *rs;
-    unsigned char *data;
+    uint8_t *data;
     int block_size = 50000;
     //multi shards encoding
     int data_size = 13*block_size*6;
@@ -557,7 +558,7 @@ void test_reconstruct(void) {
 double benchmarkEncodeTest(int n, int dataShards, int parityShards, int shardSize) {
     clock_t start, end;
     double millis;
-    unsigned char* data;
+    uint8_t* data;
     int i;
     int dataSize = shardSize*dataShards;
     reed_solomon* rs = reed_solomon_new(dataShards, parityShards);
@@ -614,13 +615,13 @@ void test_002(void) {
     char text[] = "hello world", output[256];
     int block_size = 1;
     int nrDataBlocks = sizeof(text)/sizeof(char) - 1;
-    unsigned char* data_blocks[128];
-    unsigned char* fec_blocks[128];
+    uint8_t* data_blocks[128];
+    uint8_t* fec_blocks[128];
     int nrFecBlocks = 6;
 
     //decode
     unsigned int fec_block_nos[128], erased_blocks[128];
-    unsigned char* dec_fec_blocks[128];
+    uint8_t* dec_fec_blocks[128];
     int nr_fec_blocks;
 
     int i;
@@ -629,13 +630,13 @@ void test_002(void) {
     printf("%s:\n", __FUNCTION__);
 
     for(i = 0; i < nrDataBlocks; i++) {
-        data_blocks[i] = (unsigned char*)&text[i];
+        data_blocks[i] = (uint8_t*)&text[i];
     }
 
     memset(output, 0, sizeof(output));
     memcpy(output, text, nrDataBlocks);
     for(i = 0; i < nrFecBlocks; i++) {
-        fec_blocks[i] = (unsigned char*)&output[i + nrDataBlocks];
+        fec_blocks[i] = (uint8_t*)&output[i + nrDataBlocks];
     }
 
     reed_solomon_encode(rs, data_blocks, fec_blocks, block_size);
@@ -670,13 +671,13 @@ void test_003(void) {
     char text[] = "hello world hello world ", output[256];
     int block_size = 2;
     int nrDataBlocks = (sizeof(text)/sizeof(char) - 1) / block_size;
-    unsigned char* data_blocks[128];
-    unsigned char* fec_blocks[128];
+    uint8_t* data_blocks[128];
+    uint8_t* fec_blocks[128];
     int nrFecBlocks = 6;
 
     //decode
     unsigned int fec_block_nos[128], erased_blocks[128];
-    unsigned char* dec_fec_blocks[128];
+    uint8_t* dec_fec_blocks[128];
     int nr_fec_blocks;
 
     int i;
@@ -686,14 +687,14 @@ void test_003(void) {
     //printf("text size=%d\n", (int)(sizeof(text)/sizeof(char) - 1) );
 
     for(i = 0; i < nrDataBlocks; i++) {
-        data_blocks[i] = (unsigned char*)&text[i*block_size];
+        data_blocks[i] = (uint8_t*)&text[i*block_size];
     }
 
     memset(output, 0, sizeof(output));
     memcpy(output, text, nrDataBlocks*block_size);
     //print_matrix1((gf*)output, nrDataBlocks + nrFecBlocks, block_size);
     for(i = 0; i < nrFecBlocks; i++) {
-        fec_blocks[i] = (unsigned char*)&output[i*block_size + nrDataBlocks*block_size];
+        fec_blocks[i] = (uint8_t*)&output[i*block_size + nrDataBlocks*block_size];
     }
     reed_solomon_encode(rs, data_blocks, fec_blocks, block_size);
     printf("golang output(example/test_rs.go):\n [[104 101] [108 108] [111 32] [119 111] [114 108] [100 32] [104 101] [108 108] [111 32] [119 111] [114 108] [100 32] \n[157 178] [83 31] [48 240] [254 93] [31 89] [151 184]]\n");
@@ -734,9 +735,9 @@ void test_004(void) {
     int blockSize = 280;
     struct timeval tv;
     int i, j, n, seed, size, nrShards, nrBlocks, nrFecBlocks;
-    unsigned char *origin, *data;
-    unsigned char **data_blocks;
-    unsigned char *zilch;
+    uint8_t *origin, *data;
+    uint8_t **data_blocks;
+    uint8_t *zilch;
     reed_solomon *rs;
 
     gettimeofday(&tv, 0);
@@ -750,7 +751,7 @@ void test_004(void) {
     origin = malloc(size);
     //memcpy(origin, text, size);
     for(i = 0; i < size; i++) {
-        origin[i] = (unsigned char)(random() % 255);
+        origin[i] = (uint8_t)(random() % 255);
     }
 
     nrBlocks = (size+blockSize-1) / blockSize;
@@ -765,7 +766,7 @@ void test_004(void) {
     //print_buf(origin, "%d ", size);
     //print_buf(data, "%d ", nrShards*blockSize);
 
-    data_blocks = (unsigned char**)malloc( nrShards * sizeof(unsigned char**) );
+    data_blocks = (uint8_t**)malloc( nrShards * sizeof(uint8_t**) );
     for(i = 0; i < nrShards; i++) {
         data_blocks[i] = data + i*blockSize;
     }
@@ -776,7 +777,7 @@ void test_004(void) {
     assert(0 == i);
     //print_matrix2(data_blocks, nrShards, blockSize);
 
-    zilch = (unsigned char*)calloc(1, nrShards);
+    zilch = (uint8_t*)calloc(1, nrShards);
     n = parityShards;
 
     /* int es[100];


### PR DESCRIPTION
From: https://github.com/jannson/reedsolomon-c

---

First round of implementation can do the following:

Upload:
- Use memory-mapped file of original file and encode parity shards to another memory-mapped file in a temporary directory
- Upload and encrypt the additional parity shards, as similar to uploading the standard shards, however indicating additional meta-data for the shard to indicate that it's a parity shard and it's index and position

Download:
- Download into a memory-mapped file and decrypt
- When a shard can't be downloaded, queue requests for parity shards and attempt to download and decrypt into to a temporary parity mapped file
- Reconstruct missing shards using parity shards

Notes:
- Use with memory mapped files has been tested at https://github.com/braydonf/reedsolomon-c/blob/mmap/examples/simple-encoder.c
- If it's necessary to encode after encryption, this above implementation can be modified to meet that goal.

---

Closes: https://github.com/Storj/libstorj/issues/250