### PR TITLE
Support Windows 7 for `get_time_milliseconds`

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -113,7 +113,7 @@ uint64_t get_time_milliseconds() {
 
     FILETIME ft;
 
-    GetSystemTimePreciseAsFileTime(&ft);
+    GetSystemTimeAsFileTime(&ft);
 
     LARGE_INTEGER li;
     li.LowPart = ft.dwLowDateTime;


### PR DESCRIPTION
GetSystemTimePreciseAsFileTime is support from Windows 8, and
GetSystemTimeAsFileTime is supported from Windows 2000.

https://msdn.microsoft.com/en-us/library/windows/desktop/ms724397(v=vs.85).aspx

Closes https://github.com/Storj/libstorj/issues/269