### PR TITLE
Add hexdump

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ sudo make install
 
 Development tools:
 ```bash
-apt-get install build-essential libtool autotools-dev automake libmicrohttpd-dev
+apt-get install build-essential libtool autotools-dev automake libmicrohttpd-dev bsdmainutils
 ```
 
 Dependencies:


### PR DESCRIPTION
`hexdump` is provided by the [bsdmainutils](https://packages.debian.org/sid/amd64/bsdmainutils/filelist) package and is required for the tests.