### PR TITLE
Shard size improvements for reed solomon encoding

### DIFF
--- a/src/rs.h
+++ b/src/rs.h
@@ -45,7 +45,8 @@ void reed_solomon_release(reed_solomon* rs);
 int reed_solomon_encode(reed_solomon* rs,
                         uint8_t** data_blocks,
                         uint8_t** fec_blocks,
-                        int block_size);
+                        int block_size,
+                        uint64_t total_bytes);
 
 
 /**
@@ -64,7 +65,8 @@ int reed_solomon_decode(reed_solomon* rs,
                         uint8_t **dec_fec_blocks,
                         unsigned int *fec_block_nos,
                         unsigned int *erased_blocks,
-                        int nr_fec_blocks);
+                        int nr_fec_blocks,
+                        uint64_t total_bytes);
 
 /**
  * encode a big size of buffer
@@ -74,7 +76,8 @@ int reed_solomon_decode(reed_solomon* rs,
  * shards[nr_shards][block_size]
  * */
 int reed_solomon_encode2(reed_solomon* rs, uint8_t** data_blocks,
-                         uint8_t** fec_blocks, int nr_shards, int block_size);
+                         uint8_t** fec_blocks, int nr_shards, int block_size,
+                         uint64_t total_bytes);
 
 /**
  * reconstruct a big size of buffer
@@ -86,5 +89,6 @@ int reed_solomon_encode2(reed_solomon* rs, uint8_t** data_blocks,
  * */
 int reed_solomon_reconstruct(reed_solomon* rs, uint8_t** data_blocks,
                              uint8_t** fec_blocks, uint8_t* marks,
-                             int nr_shards, int block_size);
+                             int nr_shards, int block_size,
+                             uint64_t total_bytes);
 #endif


### PR DESCRIPTION
- Parity shards will be encoded to the full block size, zeros will be assumed for the source when it's not available (the last shard)
- During reconstruction and decoding the repaired blocks will automatically truncate zero padding
- Requires knowing the original size for decoding
- Provides ability to use multiple of 8MiB shard size
- Padding is handled at the library for use with memory mapped files

Testing: https://github.com/braydonf/reedsolomon-c/tree/mmap