### PR TITLE
Mingw build fixes

### DIFF
--- a/src/rs.c
+++ b/src/rs.c
@@ -293,49 +293,21 @@ static void generate_gf(void)
     if (c != 0) addmul1(dst, src, c, sz, dst_max, src_max)
 #endif
 
-#define UNROLL 0 /* 1, 4, 8, 16 */
 static void slow_addmul1(gf *dst1, gf *src1, gf c, int64_t sz, int64_t dst_max, int64_t src_max)
 {
     USE_GF_MULC;
     register gf *dst = dst1, *src = src1;
     int64_t low_max = dst_max < src_max ? dst_max : src_max;
-    int64_t dif = sz - low_max;
-    int64_t pos = low_max - UNROLL + 1;
-    gf *lim = &dst[pos];
+    int64_t pos = 0;
+    gf *lim = &dst[low_max];
 
     GF_MULC0(c);
 
-#if (UNROLL > 1) /* unrolling by 8/16 is quite effective on the pentium */
-    for (; dst < lim; dst += UNROLL, src += UNROLL ) {
-        GF_ADDMULC( dst[0] , src[0] );
-        GF_ADDMULC( dst[1] , src[1] );
-        GF_ADDMULC( dst[2] , src[2] );
-        GF_ADDMULC( dst[3] , src[3] );
-#if (UNROLL > 4)
-        GF_ADDMULC( dst[4] , src[4] );
-        GF_ADDMULC( dst[5] , src[5] );
-        GF_ADDMULC( dst[6] , src[6] );
-        GF_ADDMULC( dst[7] , src[7] );
-#endif
-#if (UNROLL > 8)
-        GF_ADDMULC( dst[8] , src[8] );
-        GF_ADDMULC( dst[9] , src[9] );
-        GF_ADDMULC( dst[10] , src[10] );
-        GF_ADDMULC( dst[11] , src[11] );
-        GF_ADDMULC( dst[12] , src[12] );
-        GF_ADDMULC( dst[13] , src[13] );
-        GF_ADDMULC( dst[14] , src[14] );
-        GF_ADDMULC( dst[15] , src[15] );
-#endif
-    }
-#endif
-    lim += dif + UNROLL - 1;
-    /* final components */
     for (; dst < lim; dst++, src++ ) {
         if (pos < src_max && pos < dst_max) {
             GF_ADDMULC( *dst , *src );
         } else if (pos < dst_max) {
-            /* assume zero when post the max */
+            /* assume zero when past the max */
             GF_ADDMULC( *dst , 0 );
         }
         pos += 1;
@@ -363,50 +335,21 @@ static void addmul(gf *dst, gf *src, gf c, int64_t sz, int64_t dst_max, int64_t 
     do { if (c != 0) mul1(dst, src, c, sz, dst_max, src_max); else memset(dst, 0, c); } while(0)
 #endif
 
-#define UNROLL 0 /* 1, 4, 8, 16 */
 static void slow_mul1(gf *dst1, gf *src1, gf c, int64_t sz, int64_t dst_max, int64_t src_max)
 {
     USE_GF_MULC;
     register gf *dst = dst1, *src = src1;
-
     int64_t low_max = dst_max < src_max ? dst_max : src_max;
-    int64_t dif = sz - low_max;
-    int64_t pos = low_max - UNROLL + 1;
-    gf *lim = &dst[pos];
+    int64_t pos = 0;
+    gf *lim = &dst[low_max];
 
     GF_MULC0(c);
 
-#if (UNROLL > 1) /* unrolling by 8/16 is quite effective on the pentium */
-    for (; dst < lim; dst += UNROLL, src += UNROLL ) {
-        GF_MULC( dst[0] , src[0] );
-        GF_MULC( dst[1] , src[1] );
-        GF_MULC( dst[2] , src[2] );
-        GF_MULC( dst[3] , src[3] );
-#if (UNROLL > 4)
-        GF_MULC( dst[4] , src[4] );
-        GF_MULC( dst[5] , src[5] );
-        GF_MULC( dst[6] , src[6] );
-        GF_MULC( dst[7] , src[7] );
-#endif
-#if (UNROLL > 8)
-        GF_MULC( dst[8] , src[8] );
-        GF_MULC( dst[9] , src[9] );
-        GF_MULC( dst[10] , src[10] );
-        GF_MULC( dst[11] , src[11] );
-        GF_MULC( dst[12] , src[12] );
-        GF_MULC( dst[13] , src[13] );
-        GF_MULC( dst[14] , src[14] );
-        GF_MULC( dst[15] , src[15] );
-#endif
-    }
-#endif
-    lim += dif + UNROLL - 1;
-    /* final components */
     for (; dst < lim; dst++, src++ ) {
         if (pos < src_max && pos < dst_max) {
             GF_MULC( *dst , *src );
         } else if (pos < dst_max) {
-            /* assume zero when post the max */
+            /* assume zero when past the max */
             GF_MULC( *dst , 0 );
         }
         pos += 1;

--- a/src/rs.c
+++ b/src/rs.c
@@ -293,7 +293,7 @@ static void generate_gf(void)
     if (c != 0) addmul1(dst, src, c, sz, dst_max, src_max)
 #endif
 
-#define UNROLL 16 /* 1, 4, 8, 16 */
+#define UNROLL 0 /* 1, 4, 8, 16 */
 static void slow_addmul1(gf *dst1, gf *src1, gf c, int64_t sz, int64_t dst_max, int64_t src_max)
 {
     USE_GF_MULC;
@@ -363,7 +363,7 @@ static void addmul(gf *dst, gf *src, gf c, int64_t sz, int64_t dst_max, int64_t 
     do { if (c != 0) mul1(dst, src, c, sz, dst_max, src_max); else memset(dst, 0, c); } while(0)
 #endif
 
-#define UNROLL 16 /* 1, 4, 8, 16 */
+#define UNROLL 0 /* 1, 4, 8, 16 */
 static void slow_mul1(gf *dst1, gf *src1, gf c, int64_t sz, int64_t dst_max, int64_t src_max)
 {
     USE_GF_MULC;

--- a/src/rs.c
+++ b/src/rs.c
@@ -293,12 +293,12 @@ static void generate_gf(void)
     if (c != 0) addmul1(dst, src, c, sz, dst_max, src_max)
 #endif
 
-static void slow_addmul1(gf *dst1, gf *src1, gf c, int64_t sz, int64_t dst_max, int64_t src_max)
+static void slow_addmul1(gf *dst1, gf *src1, gf c, uint64_t sz, uint64_t dst_max, uint64_t src_max)
 {
     USE_GF_MULC;
     register gf *dst = dst1, *src = src1;
-    int64_t low_max = dst_max < src_max ? dst_max : src_max;
-    int64_t pos = 0;
+    uint64_t low_max = dst_max < src_max ? dst_max : src_max;
+    uint64_t pos = 0;
     gf *lim = &dst[low_max];
 
     GF_MULC0(c);
@@ -316,7 +316,7 @@ static void slow_addmul1(gf *dst1, gf *src1, gf c, int64_t sz, int64_t dst_max, 
 
 # define addmul1 slow_addmul1
 
-static void addmul(gf *dst, gf *src, gf c, int64_t sz, int64_t dst_max, int64_t src_max)
+static void addmul(gf *dst, gf *src, gf c, uint64_t sz, uint64_t dst_max, uint64_t src_max)
 {
     if (c != 0) addmul1(dst, src, c, sz, dst_max, src_max);
 }
@@ -335,12 +335,12 @@ static void addmul(gf *dst, gf *src, gf c, int64_t sz, int64_t dst_max, int64_t 
     do { if (c != 0) mul1(dst, src, c, sz, dst_max, src_max); else memset(dst, 0, c); } while(0)
 #endif
 
-static void slow_mul1(gf *dst1, gf *src1, gf c, int64_t sz, int64_t dst_max, int64_t src_max)
+static void slow_mul1(gf *dst1, gf *src1, gf c, uint64_t sz, uint64_t dst_max, uint64_t src_max)
 {
     USE_GF_MULC;
     register gf *dst = dst1, *src = src1;
-    int64_t low_max = dst_max < src_max ? dst_max : src_max;
-    int64_t pos = 0;
+    uint64_t low_max = dst_max < src_max ? dst_max : src_max;
+    uint64_t pos = 0;
     gf *lim = &dst[low_max];
 
     GF_MULC0(c);
@@ -358,7 +358,7 @@ static void slow_mul1(gf *dst1, gf *src1, gf c, int64_t sz, int64_t dst_max, int
 
 # define mul1 slow_mul1
 
-static inline void mul(gf *dst, gf *src, gf c, int64_t sz, int64_t dst_max, int64_t src_max)
+static inline void mul(gf *dst, gf *src, gf c, uint64_t sz, uint64_t dst_max, uint64_t src_max)
 {
     if (c != 0) mul1(dst, src, c, sz, dst_max, src_max); else memset(dst, 0, c);
 }

--- a/src/uploader.c
+++ b/src/uploader.c
@@ -1845,12 +1845,13 @@ static void create_parity_shards(uv_work_t *work)
         goto clean_variables;
     }
 
-    int falloc_status = allocatefile(fileno(parity_file), 0, parity_size);
+    int falloc_status = allocatefile(fileno(parity_file), parity_size);
 
     if (falloc_status) {
         req->error_status = 1;
         state->log->error(state->env->log_options, state->handle,
-                          "Could not allocate space for mmap parity shard file: %s", strerror(errno));
+                          "Could not allocate space for mmap parity " \
+                          "shard file: %i", falloc_status);
         goto clean_variables;
     }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -223,7 +223,7 @@ ssize_t pwrite(int fd, const void *buf, size_t count, uint64_t offset)
 }
 #endif
 
-int allocatefile(int fd, off_t offset, off_t length)
+int allocatefile(int fd, uint64_t length)
 {
 #ifdef _WIN32
     HANDLE file = (HANDLE)_get_osfhandle(fd);
@@ -251,13 +251,13 @@ win_finished:
 
     return status;
 #elif HAVE_POSIX_FALLOCATE
-    return posix_fallocate(fd, offset, length);
+    return posix_fallocate(fd, 0, length);
 #elif __unix__
-    return fallocate(fd, FALLOC_FL_ZERO_RANGE, offset, length);
+    return fallocate(fd, FALLOC_FL_ZERO_RANGE, 0, length);
 #elif __linux__
-    return fallocate(fd, FALLOC_FL_ZERO_RANGE, offset, length);
+    return fallocate(fd, FALLOC_FL_ZERO_RANGE, 0, length);
 #elif __APPLE__
-    fstore_t store = {F_ALLOCATECONTIG, F_PEOFPOSMODE, offset, length, 0};
+    fstore_t store = {F_ALLOCATECONTIG, F_PEOFPOSMODE, 0, length, 0};
     // Try to get a continous chunk of disk space
     int ret = fcntl(fd, F_PREALLOCATE, &store);
     if (-1 == ret) {
@@ -268,7 +268,7 @@ win_finished:
             return -1;
         }
     }
-    return ftruncate(fd, offset+length);
+    return ftruncate(fd, length);
 #else
     return -1;
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -37,7 +37,7 @@ ssize_t pwrite(int fd, const void *buf, size_t count, uint64_t offset);
 #define MAX_SHARD_SIZE 4294967296 // 4Gb
 #define SHARD_MULTIPLES_BACK 4
 
-int allocatefile(int fd, off_t offset, off_t length);
+int allocatefile(int fd, uint64_t length);
 
 char *hex2str(size_t length, uint8_t *data);
 


### PR DESCRIPTION
Fixes page fault when encoding parity shards when uploading files >4GB *(4379901952 bytes)* on windows, likely fixes similar issue on download.