### PR TITLE
Remove use of bucket token when downloading

### DIFF
--- a/src/downloader.c
+++ b/src/downloader.c
@@ -579,7 +579,7 @@ static void queue_request_pointers(storj_download_state_t *state)
 
     char query_args[BUFSIZ];
     memset(query_args, '\0', BUFSIZ);
-    snprintf(query_args, BUFSIZ, "?limit=6&skip=%d", state->total_pointers);
+    snprintf(query_args, BUFSIZ, "?limit=3&skip=%d", state->total_pointers);
 
     int path_len = 9 + strlen(state->bucket_id) + 7 +
         strlen(state->file_id) + strlen(query_args);

--- a/src/downloader.h
+++ b/src/downloader.h
@@ -124,7 +124,6 @@ typedef struct {
     storj_http_options_t *http_options;
     storj_bridge_options_t *options;
     uint32_t pointer_index;
-    char *token;
     const char *bucket_id;
     const char *file_id;
     char *excluded_farmer_ids;
@@ -144,28 +143,12 @@ typedef struct {
     char *method;
     char *path;
     bool auth;
-    char *token;
     struct json_object *body;
     struct json_object *response;
     /* state should not be modified in worker threads */
     storj_download_state_t *state;
     int status_code;
 } json_request_download_t;
-
-/** @brief A structure for sharing data with worker threads for requesting
- * a bucket operation token from the bridge.
- */
-typedef struct {
-    storj_http_options_t *http_options;
-    storj_bridge_options_t *options;
-    char *token;
-    const char *bucket_id;
-    char *bucket_op;
-    /* state should not be modified in worker threads */
-    storj_download_state_t *state;
-    int status_code;
-    int error_status;
-} token_request_download_t;
 
 /** @brief A method that determines the next work necessary to download a file
  *

--- a/src/http.c
+++ b/src/http.c
@@ -503,7 +503,6 @@ int fetch_json(storj_http_options_t *http_options,
                char *path,
                struct json_object *request_body,
                bool auth,
-               char *token,
                struct json_object **response,
                int *status_code)
 {
@@ -602,17 +601,6 @@ int fetch_json(storj_http_options_t *http_options,
     }
 
     struct curl_slist *header_list = NULL;
-    if (token) {
-        char *token_header = calloc(9 + strlen(token) + 1, sizeof(char));
-        if (!token_header) {
-            return 1;
-        }
-        strcat(token_header, "X-Token: ");
-        strcat(token_header, token);
-        header_list = curl_slist_append(header_list, token_header);
-        free(token_header);
-        curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header_list);
-    }
 
     // Include body if request body json is provided
     http_body_send_t *post_body = NULL;

--- a/src/http.h
+++ b/src/http.h
@@ -168,7 +168,6 @@ int fetch_json(storj_http_options_t *http_options,
                char *path,
                struct json_object *request_body,
                bool auth,
-               char *token,
                struct json_object **response,
                int *status_code);
 

--- a/src/storj.c
+++ b/src/storj.c
@@ -12,7 +12,7 @@ static void json_request_worker(uv_work_t *work)
 
     req->error_code = fetch_json(req->http_options,
                                  req->options, req->method, req->path, req->body,
-                                 req->auth, NULL, &req->response, &status_code);
+                                 req->auth, &req->response, &status_code);
 
     req->status_code = status_code;
 }
@@ -64,7 +64,7 @@ static void create_bucket_request_worker(uv_work_t *work)
 
     req->error_code = fetch_json(req->http_options,
                                  req->bridge_options, "POST", "/buckets", body,
-                                 true, NULL, &req->response, &status_code);
+                                 true, &req->response, &status_code);
 
     json_object_put(body);
 
@@ -89,7 +89,7 @@ static void get_buckets_request_worker(uv_work_t *work)
 
     req->error_code = fetch_json(req->http_options,
                                  req->options, req->method, req->path, req->body,
-                                 req->auth, NULL, &req->response, &status_code);
+                                 req->auth, &req->response, &status_code);
 
     req->status_code = status_code;
 
@@ -173,7 +173,7 @@ static void list_files_request_worker(uv_work_t *work)
 
     req->error_code = fetch_json(req->http_options,
                                  req->options, req->method, req->path, req->body,
-                                 req->auth, NULL, &req->response, &status_code);
+                                 req->auth, &req->response, &status_code);
 
     req->status_code = status_code;
 

--- a/src/storj.h
+++ b/src/storj.h
@@ -410,9 +410,6 @@ typedef struct {
     bool requesting_pointers;
     int error_status;
     bool writing;
-    char *token;
-    bool requesting_token;
-    uint32_t token_fail_count;
     uint8_t *decrypt_key;
     uint8_t *decrypt_ctr;
     const char *hmac;

--- a/src/uploader.c
+++ b/src/uploader.c
@@ -439,7 +439,6 @@ static void create_bucket_entry(uv_work_t *work)
                                     path,
                                     body,
                                     true,
-                                    NULL,
                                     &req->response,
                                     &status_code);
 
@@ -1069,7 +1068,6 @@ static void push_frame(uv_work_t *work)
                                     resource,
                                     body,
                                     true,
-                                    NULL,
                                     &response,
                                     &status_code);
 
@@ -1712,7 +1710,6 @@ static void request_frame_id(uv_work_t *work)
                                     "/frames",
                                     body,
                                     true,
-                                    NULL,
                                     &response,
                                     &status_code);
 
@@ -2050,7 +2047,7 @@ static void send_exchange_report(uv_work_t *work)
     int request_status = fetch_json(req->http_options,
                                     req->options, "POST",
                                     "/reports/exchanges", body,
-                                    NULL, NULL, &response, &status_code);
+                                    true, &response, &status_code);
 
 
     if (request_status) {
@@ -2197,7 +2194,7 @@ static void verify_file_name(uv_work_t *work)
 
     req->error_code = fetch_json(req->http_options,
                                  req->options, req->method, req->path, req->body,
-                                 req->auth, NULL, &req->response, &status_code);
+                                 req->auth, &req->response, &status_code);
 
     req->status_code = status_code;
 }

--- a/test/mockbridge.c
+++ b/test/mockbridge.c
@@ -112,11 +112,20 @@ int mock_bridge_server(void *cls,
             if (!skip || 0 == strcmp(skip, "0")) {
                 page = get_response_string(responses, "getfilepointers-0");
                 status_code = MHD_HTTP_OK;
-            } else if (0 == strcmp(skip, "6")) {
+            } else if (0 == strcmp(skip, "3")) {
                 page = get_response_string(responses, "getfilepointers-1");
                 status_code = MHD_HTTP_OK;
-            } else if (0 == strcmp(skip, "12")) {
+            } else if (0 == strcmp(skip, "6")) {
                 page = get_response_string(responses, "getfilepointers-2");
+                status_code = MHD_HTTP_OK;
+            } else if (0 == strcmp(skip, "9")) {
+                page = get_response_string(responses, "getfilepointers-3");
+                status_code = MHD_HTTP_OK;
+            } else if (0 == strcmp(skip, "12")) {
+                page = get_response_string(responses, "getfilepointers-4");
+                status_code = MHD_HTTP_OK;
+            } else if (0 == strcmp(skip, "15")) {
+                page = get_response_string(responses, "getfilepointers-5");
                 status_code = MHD_HTTP_OK;
             } else if (0 == strcmp(skip, "4")) {
                 // TODO check exclude and limit query

--- a/test/mockbridge.json
+++ b/test/mockbridge.json
@@ -305,7 +305,9 @@
       "operation": "PULL",
       "index": 2,
       "size": 16777216
-    },
+    }
+  ],
+  "getfilepointers-1": [
     {
       "token": "cc02fb5c9687c397fd1ead5a2e71239dcffb0f4c",
       "hash": "214ed86cb1287fe0fd18c174eecbf84341bf2655",
@@ -352,7 +354,7 @@
       "size": 16777216
     }
   ],
-  "getfilepointers-1": [
+  "getfilepointers-2": [
     {
       "token": "de8e83dcf41789d66f2855259f35b729c9834eeb",
       "hash": "ebcbe78dd209a03d3ce29f2e5460304de2060031",
@@ -387,7 +389,9 @@
       "hash": "88c5e8885160c449b1dbb00ccf317067200b39a0",
       "index": 8,
       "size": 16777216
-    },
+    }
+  ],
+  "getfilepointers-3": [
     {
       "token": "cc02fb5c9687c397fd1ead5a2e71239dcffb0f4c",
       "hash": "76b1a97498e026c47c924374b5b1148543d5c0ab",
@@ -434,7 +438,7 @@
       "size": 16777216
     }
   ],
-  "getfilepointers-2": [
+  "getfilepointers-4": [
     {
       "token": "de8e83dcf41789d66f2855259f35b729c9834eeb",
       "hash": "973701b43290e3bef7007db0cb75744f9556ae3b",
@@ -480,7 +484,9 @@
       "index": 14,
       "parity": true,
       "size": 16777216
-    },
+    }
+  ],
+  "getfilepointers-5": [
     {
       "token": "3b3f8ccb23ec47cec1ad57f7f68cab285dde54d6",
       "hash": "424cdf090604317570da38ef7d5b41abea0952df",


### PR DESCRIPTION
Reduces the overall requests to the bridge by around 1/3 when downloading files.

And decreases the limit from 6 to 3 pointers per request to improve timeouts when API requests are set to timeout in 20 seconds instead of 60 seconds.

Closes: https://github.com/Storj/libstorj/issues/340
Depends: https://github.com/Storj/bridge/pull/452