### PR TITLE
[WIP] Building shared library for the release

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_INIT([libstorj],[1.0.1])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([build-aux/m4])
 AM_INIT_AUTOMAKE([foreign])
-LT_INIT([win32-dll])
+LT_INIT([shared static win32-dll])
 
 AC_PATH_PROG(HEXDUMP,hexdump)
 

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -92,7 +92,7 @@ define build_source
 	echo "====================================\n\n" && \
 	export PATH="$(TOOLCHAIN_BUILD_DIR)bin:${PATH}" && \
 	if test -f "./autogen.sh"; then ./autogen.sh; fi && \
-	$(build_env) $($(1)_config_env) ./configure --host="$(HOST)" $($(1)_config_opts) $(config_lib_type) --prefix=$(PREFIX_DIR) || exit && \
+	$(build_env) $($(1)_config_env) ./configure --host="$(HOST)" $($(1)_config_opts) $(config_lib_type) --with-pic --prefix=$(PREFIX_DIR) || exit && \
 	make || exit && \
 	make install || exit && \
 	cd "$(CURDIR)"


### PR DESCRIPTION
Was able to get `.so` build at commit 730ed0e543e2f543175e20d920886b0672076fe8 with:
```
PKG_CONFIG_LIBDIR="$(pwd)/depends/build/x86_64-pc-linux-gnu/lib/pkgconfig" CFLAGS="-I$(pwd)/depends/build/x86_64-pc-linux-gnu/include -L$(pwd)/depends/build/x86_64-pc-linux-gnu/lib" ./configure --host=x86_64-pc-linux-gnu --disable-static --enable-shared --prefix=$(pwd)/release/x86_64-pc-linux-gnu
```

Reference: https://github.com/braydonf/autotools-boilerplate

Closes https://github.com/Storj/libstorj/issues/228