### PR TITLE
Add 'cainfo_path' option to 'storj_http_options'

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -120,6 +120,10 @@ int put_shard(storj_http_options_t *http_options,
         curl_easy_setopt(curl, CURLOPT_PROXY, http_options->proxy_url);
     }
 
+    if (http_options->cainfo_path) {
+        curl_easy_setopt(curl, CURLOPT_CAINFO, http_options->cainfo_path);
+    }
+
     curl_easy_setopt(curl, CURLOPT_POST, 1);
 
     struct curl_slist *header_list = NULL;
@@ -310,6 +314,10 @@ int fetch_shard(storj_http_options_t *http_options,
 
     if (http_options->proxy_url) {
         curl_easy_setopt(curl, CURLOPT_PROXY, http_options->proxy_url);
+    }
+
+    if (http_options->cainfo_path) {
+        curl_easy_setopt(curl, CURLOPT_CAINFO, http_options->cainfo_path);
     }
 
     char query_args[80];
@@ -550,7 +558,12 @@ int fetch_json(storj_http_options_t *http_options,
         curl_easy_setopt(curl, CURLOPT_PROXY, http_options->proxy_url);
     }
 
-    // Set the timeoeut
+    // Set the path to the Certificate Authority (CA) bundle
+    if (http_options->cainfo_path) {
+        curl_easy_setopt(curl, CURLOPT_CAINFO, http_options->cainfo_path);
+    }
+
+    // Set the timeout
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, http_options->timeout);
 
     // Setup the body handler

--- a/src/storj.c
+++ b/src/storj.c
@@ -653,6 +653,11 @@ struct storj_env *storj_init_env(storj_bridge_options_t *options,
     } else {
         ho->proxy_url = NULL;
     }
+    if (http_options->cainfo_path) {
+        ho->cainfo_path = strdup(http_options->cainfo_path);
+    } else {
+        ho->cainfo_path = NULL;
+    }
     ho->low_speed_limit = http_options->low_speed_limit;
     ho->low_speed_time = http_options->low_speed_time;
     if (http_options->timeout == 0 ||
@@ -764,6 +769,9 @@ int storj_destroy_env(storj_env_t *env)
     free((char *)env->http_options->user_agent);
     if (env->http_options->proxy_url) {
         free((char *)env->http_options->proxy_url);
+    }
+    if (env->http_options->cainfo_path) {
+        free((char *)env->http_options->cainfo_path);
     }
     free(env->http_options);
 

--- a/src/storj.h
+++ b/src/storj.h
@@ -151,6 +151,7 @@ typedef struct storj_encrypt_options {
 typedef struct storj_http_options {
     const char *user_agent;
     const char *proxy_url;
+    const char *cainfo_path;
     uint64_t low_speed_limit;
     uint64_t low_speed_time;
     uint64_t timeout;


### PR DESCRIPTION
The 'cainfo_path' options sets the path to the Certificate Authority (CA) bundle. The value is then used to set the CURLOPT_CAINFO option to avoid the CURLE_SSL_CACERT error on systems (like Android) that have no suitable CA bundle.

I need this for the [Android app](https://github.com/kaloyan-raev/hello-storj) I am developing. I can pack the CA bundle in the APK, extract it on a suitable location on the Android device upon app startup and then pass this location as 'cainfo_path' option to libstorj.