### PR TITLE
Windows 64bit shared library build

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,26 @@ Configure command for libstorj-c:
 PKG_CONFIG_LIBDIR="$(pwd)/depends/build/x86_64-w64-mingw32/lib/pkgconfig" CFLAGS="-DCURL_STATICLIB -I$(pwd)/depends/build/x86_64-w64-mingw32/include -L$(pwd)/depends/build/x86_64-w64-mingw32/lib -static" ./configure --host=x86_64-w64-mingw32 --enable-static --disable-shared --prefix=$(pwd)/depends/build/x86_64-w64-mingw32
 ```
 
+**Windows Shared Library (DLL)**
+
+Supported hosts include:
+- x86_64-w64-mingw32
+
+Dependencies:
+```
+apt-get install gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64
+```
+
+```
+cd ./depends
+make HOST="x86_64-w64-mingw32" BUILD_DLL=1
+```
+
+Configure command for libstorj-c:
+```
+PKG_CONFIG_LIBDIR="$(pwd)/depends/build/x86_64-w64-mingw32/lib/pkgconfig" CFLAGS="-I$(pwd)/depends/build/x86_64-w64-mingw32/include -L$(pwd)/depends/build/x86_64-w64-mingw32/lib -DSTORJDLL" ./configure --host=x86_64-w64-mingw32 --prefix=$(pwd)/depends/build/x86_64-w64-mingw32
+```
+
 **ARM GNU/Linux**
 
 Supported hosts include:

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_INIT([libstorj],[1.0.1])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([build-aux/m4])
 AM_INIT_AUTOMAKE([foreign])
-LT_INIT
+LT_INIT([win32-dll])
 
 AC_PATH_PROG(HEXDUMP,hexdump)
 
@@ -19,7 +19,6 @@ PKG_CHECK_MODULES([LIBCURL], [libcurl >= 7.35.0],, [AC_MSG_ERROR([libcurl 7.35.0
 AC_CHECK_HEADERS([curl/curl.h], [libcurl_found_headers=yes; break;])
 AS_IF([test "x$libcurl_found_headers" != "xyes"],
             [AC_MSG_ERROR([Unable to find libcurl headers.])])
-
 
 PKG_CHECK_MODULES([NETTLE], [nettle >= 3.1],, [AC_MSG_ERROR([nettle 3.1 or greater was not found.
                             You can get it from https://www.lysator.liu.se/~nisse/nettle/])])
@@ -47,6 +46,8 @@ AC_CONFIG_FILES([Makefile src/Makefile test/Makefile])
 AC_CONFIG_FILES([libstorj.pc:libstorj.pc.in])
 
 AC_CHECK_FUNCS([aligned_alloc posix_memalign posix_fallocate])
+
+AM_CONDITIONAL([BUILD_STORJ_DLL], [test "x${CFLAGS/"STORJDLL"}" != x"$CFLAGS"])
 
 AC_ARG_ENABLE([debug],
         [AS_HELP_STRING([--enable-debug],

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -24,6 +24,15 @@ ifeq ($(host_os),)
 host_os=$(full_host_os)
 endif
 
+config_lib_type=--enable-static --disable-shared
+
+# mingw dll build
+ifeq ($(HOST), x86_64-w64-mingw32)
+ifeq ($(BUILD_DLL), 1)
+config_lib_type=
+endif
+endif
+
 # mac build
 DARWIN_SDK_PATH ?= "$(CURDIR)/MacOSX10.11.sdk"
 DARWIN_CFLAGS = "-target $(HOST) -isysroot $(DARWIN_SDK_PATH) -mmacosx-version-min=10.8 -mlinker-version=253.9 -pipe -I$(PREFIX_DIR)include"
@@ -77,13 +86,13 @@ define build_source
 	echo "curdir: $(CURDIR)" && \
 	echo "build_env: $(build_env)" && \
 	echo "config_env: $($(1)_config_env)" && \
-	echo "config_opts: $($(1)_config_opts)" && \
+	echo "config_opts: $($(1)_config_opts) $(config_lib_type)" && \
 	echo "host: $(HOST)" && \
 	echo "prefix: $(PREFIX_DIR)" && \
 	echo "====================================\n\n" && \
 	export PATH="$(TOOLCHAIN_BUILD_DIR)bin:${PATH}" && \
 	if test -f "./autogen.sh"; then ./autogen.sh; fi && \
-	$(build_env) $($(1)_config_env) ./configure --host="$(HOST)" $($(1)_config_opts) --enable-static --disable-shared --prefix=$(PREFIX_DIR) || exit && \
+	$(build_env) $($(1)_config_env) ./configure --host="$(HOST)" $($(1)_config_opts) $(config_lib_type) --prefix=$(PREFIX_DIR) || exit && \
 	make || exit && \
 	make install || exit && \
 	cd "$(CURDIR)"

--- a/depends/packages/gmp.mk
+++ b/depends/packages/gmp.mk
@@ -8,6 +8,11 @@ $(package)_sha256_hash=5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d
 $(package)_config_env_default=
 $(package)_config_opts_default=
 
+#mingw dll specific settings
+ifeq ($(BUILD_DLL), 1)
+$(package)_config_opts_x86_64-w64-mingw32=--disable-static --enable-shared
+endif
+
 # arm specific settings
 $(package)_config_opts_arm=--disable-assembly
 $(package)_config_opts_aarch64-linux-gnu=$($(package)_config_opts_arm)

--- a/depends/packages/gnutls.mk
+++ b/depends/packages/gnutls.mk
@@ -15,6 +15,11 @@ $(package)_config_env_x86_64-apple-darwin11=$($(package)_config_env_darwin)
 # 32 bit linux settings
 $(package)_config_env_i686-pc-linux-gnu=NETTLE_CFLAGS="-static" GMP_CFLAGS="-static" PKG_CONFIG_LIBDIR="$(PREFIX_DIR)/lib/pkgconfig" CFLAGS="-I$(PREFIX_DIR)include -L$(PREFIX_DIR)lib -static -m32" CXXFLAGS="-m32" LDFLAGS="-m32"
 
+# mingw dll specific settings
+ifeq ($(BUILD_DLL), 1)
+$(package)_config_env_x86_64-w64-mingw32=PKG_CONFIG_LIBDIR="$(PREFIX_DIR)/lib/pkgconfig" CFLAGS="-I$(PREFIX_DIR)include -L$(PREFIX_DIR)lib"
+endif
+
 # set settings based on host
 $(package)_config_env = $(if $($(package)_config_env_$(HOST)), $($(package)_config_env_$(HOST)), $($(package)_config_env_default))
 $(package)_config_opts = $(if $($(package)_config_opts_$(HOST)), $($(package)_config_opts_$(HOST)), $($(package)_config_opts_default))

--- a/depends/packages/libcurl.mk
+++ b/depends/packages/libcurl.mk
@@ -16,6 +16,11 @@ $(package)_config_env_i686-w64-mingw32=$($(package)_config_env_mingw32)
 $(package)_config_opts_x86_64-w64-mingw32=$($(package)_config_opts_mingw32)
 $(package)_config_opts_i686-w64-mingw32=$($(package)_config_opts_mingw32)
 
+#mingw dll specific settings
+ifeq ($(BUILD_DLL), 1)
+$(package)_config_env_x86_64-w64-mingw32=LIBS="-lcrypt32 -lnettle -lhogweed -lgmp" LD_LIBRARY_PATH="$(PREFIX_DIR)lib" PKG_CONFIG_LIBDIR="$(PREFIX_DIR)lib/pkgconfig" CPPFLAGS="-I$(PREFIX_DIR)include" LDFLAGS="-L$(PREFIX_DIR)lib"
+endif
+
 # 32-bit linux specific settings
 $(package)_config_env_i686-pc-linux-gnu=LIBS="-lnettle -lhogweed -lgmp" LD_LIBRARY_PATH="$(PREFIX_DIR)lib" PKG_CONFIG_LIBDIR="$(PREFIX_DIR)lib/pkgconfig" CPPFLAGS="-I$(PREFIX_DIR)include -m32" LDFLAGS="-L$(PREFIX_DIR)lib -m32"
 $(package)_config_opts_i686-pc-linux-gnu=--disable-ftp --disable-file --disable-ldap --disable-ldaps --disable-rtsp --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --enable-proxy --without-ssl --with-gnutls="$(PREFIX_DIR)" --disable-telnet --enable-threaded-resolver

--- a/depends/packages/nettle.mk
+++ b/depends/packages/nettle.mk
@@ -9,9 +9,14 @@ $(package)_config_env_default=PKG_CONFIG_LIBDIR="$(PREFIX_DIR)/lib/pkgconfig" CF
 $(package)_config_opts_default=
 
 # mingw specific settings
-$(package)_config_env_mingw32=PKG_CONFIG_LIBDIR="$(PREFIX_DIR)/lib/pkgconfig" CFLAGS="-I$(PREFIX_DIR)include -L$(PREFIX_DIR)lib"
+$(package)_config_env_mingw32=PKG_CONFIG_LIBDIR="$(PREFIX_DIR)/lib/pkgconfig" CFLAGS="-I$(PREFIX_DIR)include -L$(PREFIX_DIR)lib" -static
 $(package)_config_env_x86_64-w64-mingw32=$($(package)_config_env_mingw32)
 $(package)_config_env_i686-w64-mingw32=$($(package)_config_env_mingw32)
+
+# mingw dll specific settings
+ifeq ($(BUILD_DLL), 1)
+$(package)_config_env_x86_64-w64-mingw32=PKG_CONFIG_LIBDIR="$(PREFIX_DIR)/lib/pkgconfig" CFLAGS="-I$(PREFIX_DIR)include -L$(PREFIX_DIR)lib"
+endif
 
 # darwin specific settings
 $(package)_config_env_darwin=PKG_CONFIG_LIBDIR="$(PREFIX_DIR)/lib/pkgconfig"

--- a/depends/packages/nettle.mk
+++ b/depends/packages/nettle.mk
@@ -9,7 +9,7 @@ $(package)_config_env_default=PKG_CONFIG_LIBDIR="$(PREFIX_DIR)/lib/pkgconfig" CF
 $(package)_config_opts_default=
 
 # mingw specific settings
-$(package)_config_env_mingw32=PKG_CONFIG_LIBDIR="$(PREFIX_DIR)/lib/pkgconfig" CFLAGS="-I$(PREFIX_DIR)include -L$(PREFIX_DIR)lib -static"
+$(package)_config_env_mingw32=PKG_CONFIG_LIBDIR="$(PREFIX_DIR)/lib/pkgconfig" CFLAGS="-I$(PREFIX_DIR)include -L$(PREFIX_DIR)lib"
 $(package)_config_env_x86_64-w64-mingw32=$($(package)_config_env_mingw32)
 $(package)_config_env_i686-w64-mingw32=$($(package)_config_env_mingw32)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,10 +1,17 @@
 lib_LTLIBRARIES = libstorj.la
 libstorj_la_SOURCES = storj.c utils.c utils.h http.c http.h uploader.c uploader.h downloader.c downloader.h bip39.c bip39.h bip39_english.h crypto.c crypto.h rs.c rs.h
 libstorj_la_LIBADD = -lcurl -lnettle -ljson-c -luv -lm
-libstorj_la_LDFLAGS = -no-undefined -Wall
+libstorj_la_LDFLAGS = -Wall
+if BUILD_STORJ_DLL
+libstorj_la_LDFLAGS += -no-undefined
+endif
 include_HEADERS = storj.h
 
 bin_PROGRAMS = storj
 storj_SOURCES = cli.c storj.h
 storj_LDADD = libstorj.la
+if BUILD_STORJ_DLL
 storj_LDFLAGS = -Wall
+else
+storj_LDFLAGS = -Wall -static
+endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,10 +1,10 @@
 lib_LTLIBRARIES = libstorj.la
 libstorj_la_SOURCES = storj.c utils.c utils.h http.c http.h uploader.c uploader.h downloader.c downloader.h bip39.c bip39.h bip39_english.h crypto.c crypto.h rs.c rs.h
 libstorj_la_LIBADD = -lcurl -lnettle -ljson-c -luv -lm
-libstorj_la_LDFLAGS = -Wall
+libstorj_la_LDFLAGS = -no-undefined -Wall
 include_HEADERS = storj.h
 
 bin_PROGRAMS = storj
 storj_SOURCES = cli.c storj.h
 storj_LDADD = libstorj.la
-storj_LDFLAGS = -Wall -static
+storj_LDFLAGS = -Wall

--- a/src/downloader.c
+++ b/src/downloader.c
@@ -1844,7 +1844,7 @@ finish_up:
 
 }
 
-int storj_bridge_resolve_file_cancel(storj_download_state_t *state)
+STORJ_API int storj_bridge_resolve_file_cancel(storj_download_state_t *state)
 {
     if (state->canceled) {
         return 0;
@@ -1866,7 +1866,7 @@ int storj_bridge_resolve_file_cancel(storj_download_state_t *state)
     return 0;
 }
 
-int storj_bridge_resolve_file(storj_env_t *env,
+STORJ_API int storj_bridge_resolve_file(storj_env_t *env,
                               storj_download_state_t *state,
                               const char *bucket_id,
                               const char *file_id,

--- a/src/storj.c
+++ b/src/storj.c
@@ -470,7 +470,7 @@ static void log_formatter_error(storj_log_options_t *options, void *handle,
     va_end(args);
 }
 
-struct storj_env *storj_init_env(storj_bridge_options_t *options,
+STORJ_API struct storj_env *storj_init_env(storj_bridge_options_t *options,
                                  storj_encrypt_options_t *encrypt_options,
                                  storj_http_options_t *http_options,
                                  storj_log_options_t *log_options)
@@ -698,7 +698,7 @@ struct storj_env *storj_init_env(storj_bridge_options_t *options,
     return env;
 }
 
-int storj_destroy_env(storj_env_t *env)
+STORJ_API int storj_destroy_env(storj_env_t *env)
 {
     int status = 0;
 
@@ -782,7 +782,7 @@ int storj_destroy_env(storj_env_t *env)
     return status;
 }
 
-int storj_encrypt_auth(const char *passphrase,
+STORJ_API int storj_encrypt_auth(const char *passphrase,
                        const char *bridge_user,
                        const char *bridge_pass,
                        const char *mnemonic,
@@ -826,7 +826,7 @@ int storj_encrypt_auth(const char *passphrase,
     return 0;
 }
 
-int storj_encrypt_write_auth(const char *filepath,
+STORJ_API int storj_encrypt_write_auth(const char *filepath,
                              const char *passphrase,
                              const char *bridge_user,
                              const char *bridge_pass,
@@ -854,7 +854,7 @@ int storj_encrypt_write_auth(const char *filepath,
     return 0;
 }
 
-int storj_decrypt_auth(const char *buffer,
+STORJ_API int storj_decrypt_auth(const char *buffer,
                        const char *passphrase,
                        char **bridge_user,
                        char **bridge_pass,
@@ -902,7 +902,7 @@ clean_up:
     return status;
 }
 
-int storj_decrypt_read_auth(const char *filepath,
+STORJ_API int storj_decrypt_read_auth(const char *filepath,
                             const char *passphrase,
                             char **bridge_user,
                             char **bridge_pass,
@@ -947,22 +947,22 @@ int storj_decrypt_read_auth(const char *filepath,
 
 }
 
-uint64_t storj_util_timestamp()
+STORJ_API uint64_t storj_util_timestamp()
 {
     return get_time_milliseconds();
 }
 
-int storj_mnemonic_generate(int strength, char **buffer)
+STORJ_API int storj_mnemonic_generate(int strength, char **buffer)
 {
     return mnemonic_generate(strength, buffer);
 }
 
-bool storj_mnemonic_check(const char *mnemonic)
+STORJ_API bool storj_mnemonic_check(const char *mnemonic)
 {
     return mnemonic_check(mnemonic);
 }
 
-char *storj_strerror(int error_code)
+STORJ_API char *storj_strerror(int error_code)
 {
     switch(error_code) {
         case STORJ_BRIDGE_REQUEST_ERROR:
@@ -1052,7 +1052,7 @@ char *storj_strerror(int error_code)
     }
 }
 
-int storj_bridge_get_info(storj_env_t *env, void *handle, uv_after_work_cb cb)
+STORJ_API int storj_bridge_get_info(storj_env_t *env, void *handle, uv_after_work_cb cb)
 {
     uv_work_t *work = json_request_work_new(env,"GET", "/", NULL,
                                             false, handle);
@@ -1063,7 +1063,7 @@ int storj_bridge_get_info(storj_env_t *env, void *handle, uv_after_work_cb cb)
     return uv_queue_work(env->loop, (uv_work_t*) work, json_request_worker, cb);
 }
 
-int storj_bridge_get_buckets(storj_env_t *env, void *handle, uv_after_work_cb cb)
+STORJ_API int storj_bridge_get_buckets(storj_env_t *env, void *handle, uv_after_work_cb cb)
 {
     uv_work_t *work = uv_work_new();
     if (!work) {
@@ -1082,7 +1082,7 @@ int storj_bridge_get_buckets(storj_env_t *env, void *handle, uv_after_work_cb cb
                          get_buckets_request_worker, cb);
 }
 
-void storj_free_get_buckets_request(get_buckets_request_t *req)
+STORJ_API void storj_free_get_buckets_request(get_buckets_request_t *req)
 {
     json_object_put(req->response);
     if (req->buckets && req->total_buckets > 0) {
@@ -1094,7 +1094,7 @@ void storj_free_get_buckets_request(get_buckets_request_t *req)
     free(req);
 }
 
-int storj_bridge_create_bucket(storj_env_t *env,
+STORJ_API int storj_bridge_create_bucket(storj_env_t *env,
                                const char *name,
                                void *handle,
                                uv_after_work_cb cb)
@@ -1117,7 +1117,7 @@ int storj_bridge_create_bucket(storj_env_t *env,
                          create_bucket_request_worker, cb);
 }
 
-int storj_bridge_delete_bucket(storj_env_t *env,
+STORJ_API int storj_bridge_delete_bucket(storj_env_t *env,
                                const char *id,
                                void *handle,
                                uv_after_work_cb cb)
@@ -1136,7 +1136,7 @@ int storj_bridge_delete_bucket(storj_env_t *env,
     return uv_queue_work(env->loop, (uv_work_t*) work, json_request_worker, cb);
 }
 
-int storj_bridge_get_bucket(storj_env_t *env,
+STORJ_API int storj_bridge_get_bucket(storj_env_t *env,
                             const char *id,
                             void *handle,
                             uv_after_work_cb cb)
@@ -1155,7 +1155,7 @@ int storj_bridge_get_bucket(storj_env_t *env,
     return uv_queue_work(env->loop, (uv_work_t*) work, json_request_worker, cb);
 }
 
-int storj_bridge_list_files(storj_env_t *env,
+STORJ_API int storj_bridge_list_files(storj_env_t *env,
                             const char *id,
                             void *handle,
                             uv_after_work_cb cb)
@@ -1183,7 +1183,7 @@ int storj_bridge_list_files(storj_env_t *env,
                          list_files_request_worker, cb);
 }
 
-void storj_free_list_files_request(list_files_request_t *req)
+STORJ_API void storj_free_list_files_request(list_files_request_t *req)
 {
     json_object_put(req->response);
     free(req->path);
@@ -1196,7 +1196,7 @@ void storj_free_list_files_request(list_files_request_t *req)
     free(req);
 }
 
-int storj_bridge_create_bucket_token(storj_env_t *env,
+STORJ_API int storj_bridge_create_bucket_token(storj_env_t *env,
                                      const char *bucket_id,
                                      storj_bucket_op_t operation,
                                      void *handle,
@@ -1221,7 +1221,7 @@ int storj_bridge_create_bucket_token(storj_env_t *env,
     return uv_queue_work(env->loop, (uv_work_t*) work, json_request_worker, cb);
 }
 
-int storj_bridge_get_file_pointers(storj_env_t *env,
+STORJ_API int storj_bridge_get_file_pointers(storj_env_t *env,
                                    const char *bucket_id,
                                    const char *file_id,
                                    void *handle,
@@ -1241,7 +1241,7 @@ int storj_bridge_get_file_pointers(storj_env_t *env,
     return uv_queue_work(env->loop, (uv_work_t*) work, json_request_worker, cb);
 }
 
-int storj_bridge_delete_file(storj_env_t *env,
+STORJ_API int storj_bridge_delete_file(storj_env_t *env,
                              const char *bucket_id,
                              const char *file_id,
                              void *handle,
@@ -1261,7 +1261,7 @@ int storj_bridge_delete_file(storj_env_t *env,
     return uv_queue_work(env->loop, (uv_work_t*) work, json_request_worker, cb);
 }
 
-int storj_bridge_create_frame(storj_env_t *env,
+STORJ_API int storj_bridge_create_frame(storj_env_t *env,
                               void *handle,
                               uv_after_work_cb cb)
 {
@@ -1274,7 +1274,7 @@ int storj_bridge_create_frame(storj_env_t *env,
     return uv_queue_work(env->loop, (uv_work_t*) work, json_request_worker, cb);
 }
 
-int storj_bridge_get_frames(storj_env_t *env,
+STORJ_API int storj_bridge_get_frames(storj_env_t *env,
                             void *handle,
                             uv_after_work_cb cb)
 {
@@ -1287,7 +1287,7 @@ int storj_bridge_get_frames(storj_env_t *env,
     return uv_queue_work(env->loop, (uv_work_t*) work, json_request_worker, cb);
 }
 
-int storj_bridge_get_frame(storj_env_t *env,
+STORJ_API int storj_bridge_get_frame(storj_env_t *env,
                            const char *frame_id,
                            void *handle,
                            uv_after_work_cb cb)
@@ -1307,7 +1307,7 @@ int storj_bridge_get_frame(storj_env_t *env,
 
 }
 
-int storj_bridge_delete_frame(storj_env_t *env,
+STORJ_API int storj_bridge_delete_frame(storj_env_t *env,
                               const char *frame_id,
                               void *handle,
                               uv_after_work_cb cb)
@@ -1326,7 +1326,7 @@ int storj_bridge_delete_frame(storj_env_t *env,
     return uv_queue_work(env->loop, (uv_work_t*) work, json_request_worker, cb);
 }
 
-int storj_bridge_get_file_info(storj_env_t *env,
+STORJ_API int storj_bridge_get_file_info(storj_env_t *env,
                                const char *bucket_id,
                                const char *file_id,
                                void *handle,
@@ -1347,7 +1347,7 @@ int storj_bridge_get_file_info(storj_env_t *env,
     return uv_queue_work(env->loop, (uv_work_t*) work, json_request_worker, cb);
 }
 
-int storj_bridge_list_mirrors(storj_env_t *env,
+STORJ_API int storj_bridge_list_mirrors(storj_env_t *env,
                               const char *bucket_id,
                               const char *file_id,
                               void *handle,
@@ -1368,7 +1368,7 @@ int storj_bridge_list_mirrors(storj_env_t *env,
     return uv_queue_work(env->loop, (uv_work_t*) work, json_request_worker, cb);
 }
 
-int storj_bridge_register(storj_env_t *env,
+STORJ_API int storj_bridge_register(storj_env_t *env,
                           const char *email,
                           const char *password,
                           void *handle,

--- a/src/storj.h
+++ b/src/storj.h
@@ -13,6 +13,16 @@
 extern "C" {
 #endif
 
+#if defined(_WIN32) && defined(STORJDLL)
+  #if defined(DLL_EXPORT)
+    #define STORJ_API __declspec(dllexport)
+  #else
+    #define STORJ_API __declspec(dllimport)
+  #endif
+#else
+  #define STORJ_API
+#endif
+
 #include <assert.h>
 #include <json-c/json.h>
 #include <stdlib.h>
@@ -527,10 +537,10 @@ typedef struct {
  * @param[in] log_options - Logging settings
  * @return A null value on error, otherwise a storj_env pointer.
  */
-storj_env_t *storj_init_env(storj_bridge_options_t *options,
-                            storj_encrypt_options_t *encrypt_options,
-                            storj_http_options_t *http_options,
-                            storj_log_options_t *log_options);
+STORJ_API storj_env_t *storj_init_env(storj_bridge_options_t *options,
+                                      storj_encrypt_options_t *encrypt_options,
+                                      storj_http_options_t *http_options,
+                                      storj_log_options_t *log_options);
 
 
 /**
@@ -543,7 +553,7 @@ storj_env_t *storj_init_env(storj_bridge_options_t *options,
  *
  * @param [in] env
  */
-int storj_destroy_env(storj_env_t *env);
+STORJ_API int storj_destroy_env(storj_env_t *env);
 
 /**
  * @brief Will encrypt and write options to disk
@@ -558,11 +568,11 @@ int storj_destroy_env(storj_env_t *env);
  * @param[in] mnemonic - The file encryption mnemonic
  * @return A non-zero value on error, zero on success.
  */
-int storj_encrypt_write_auth(const char *filepath,
-                             const char *passhrase,
-                             const char *bridge_user,
-                             const char *bridge_pass,
-                             const char *mnemonic);
+STORJ_API int storj_encrypt_write_auth(const char *filepath,
+                                       const char *passhrase,
+                                       const char *bridge_user,
+                                       const char *bridge_pass,
+                                       const char *mnemonic);
 
 
 /**
@@ -578,11 +588,11 @@ int storj_encrypt_write_auth(const char *filepath,
  * @param[out] buffer - The destination buffer
  * @return A non-zero value on error, zero on success.
  */
-int storj_encrypt_auth(const char *passhrase,
-                       const char *bridge_user,
-                       const char *bridge_pass,
-                       const char *mnemonic,
-                       char **buffer);
+STORJ_API int storj_encrypt_auth(const char *passhrase,
+                                 const char *bridge_user,
+                                 const char *bridge_pass,
+                                 const char *mnemonic,
+                                 char **buffer);
 
 /**
  * @brief Will read and decrypt options from disk
@@ -597,11 +607,11 @@ int storj_encrypt_auth(const char *passhrase,
  * @param[out] mnemonic - The file encryption mnemonic
  * @return A non-zero value on error, zero on success.
  */
-int storj_decrypt_read_auth(const char *filepath,
-                            const char *passphrase,
-                            char **bridge_user,
-                            char **bridge_pass,
-                            char **mnemonic);
+ STORJ_API int storj_decrypt_read_auth(const char *filepath,
+                                       const char *passphrase,
+                                       char **bridge_user,
+                                       char **bridge_pass,
+                                       char **mnemonic);
 
 /**
  * @brief Will decrypt options
@@ -616,18 +626,18 @@ int storj_decrypt_read_auth(const char *filepath,
  * @param[out] mnemonic - The file encryption mnemonic
  * @return A non-zero value on error, zero on success.
  */
-int storj_decrypt_auth(const char *buffer,
-                       const char *passphrase,
-                       char **bridge_user,
-                       char **bridge_pass,
-                       char **mnemonic);
+STORJ_API int storj_decrypt_auth(const char *buffer,
+                                 const char *passphrase,
+                                 char **bridge_user,
+                                 char **bridge_pass,
+                                 char **mnemonic);
 
 /**
  * @brief Will get the current unix timestamp in milliseconds
  *
  * @return A unix timestamp
  */
-uint64_t storj_util_timestamp();
+STORJ_API uint64_t storj_util_timestamp();
 
 /**
  * @brief Will generate a new random mnemonic
@@ -639,7 +649,7 @@ uint64_t storj_util_timestamp();
  * @param[out] buffer - The destination of the mnemonic
  * @return A non-zero value on error, zero on success.
  */
-int storj_mnemonic_generate(int strength, char **buffer);
+STORJ_API int storj_mnemonic_generate(int strength, char **buffer);
 
 /**
  * @brief Will check that a mnemonic is valid
@@ -650,7 +660,7 @@ int storj_mnemonic_generate(int strength, char **buffer);
  * @param[in] strength - The bits of entropy
  * @return Will return true on success and false failure
  */
-bool storj_mnemonic_check(const char *mnemonic);
+STORJ_API bool storj_mnemonic_check(const char *mnemonic);
 
 /**
  * @brief Get the error message for an error code
@@ -661,7 +671,7 @@ bool storj_mnemonic_check(const char *mnemonic);
  * @param[in] error_code The storj error code integer
  * @return A char pointer with error message
  */
-char *storj_strerror(int error_code);
+STORJ_API char *storj_strerror(int error_code);
 
 /**
  * @brief Get Storj bridge API information.
@@ -675,9 +685,9 @@ char *storj_strerror(int error_code);
  * @param[in] cb A function called with response when complete
  * @return A non-zero error value on failure and 0 on success.
  */
-int storj_bridge_get_info(storj_env_t *env,
-                          void *handle,
-                          uv_after_work_cb cb);
+STORJ_API int storj_bridge_get_info(storj_env_t *env,
+                                    void *handle,
+                                    uv_after_work_cb cb);
 
 /**
  * @brief List available buckets for a user.
@@ -687,16 +697,16 @@ int storj_bridge_get_info(storj_env_t *env,
  * @param[in] cb A function called with response when complete
  * @return A non-zero error value on failure and 0 on success.
  */
-int storj_bridge_get_buckets(storj_env_t *env,
-                             void *handle,
-                             uv_after_work_cb cb);
+STORJ_API int storj_bridge_get_buckets(storj_env_t *env,
+                                       void *handle,
+                                       uv_after_work_cb cb);
 
 /**
  * @brief Will free all structs for get buckets request
  *
  * @param[in] req - The work request from storj_bridge_get_buckets callback
  */
-void storj_free_get_buckets_request(get_buckets_request_t *req);
+STORJ_API void storj_free_get_buckets_request(get_buckets_request_t *req);
 
 /**
  * @brief Create a bucket.
@@ -707,10 +717,10 @@ void storj_free_get_buckets_request(get_buckets_request_t *req);
  * @param[in] cb A function called with response when complete
  * @return A non-zero error value on failure and 0 on success.
  */
-int storj_bridge_create_bucket(storj_env_t *env,
-                               const char *name,
-                               void *handle,
-                               uv_after_work_cb cb);
+STORJ_API int storj_bridge_create_bucket(storj_env_t *env,
+                                         const char *name,
+                                         void *handle,
+                                         uv_after_work_cb cb);
 
 /**
  * @brief Delete a bucket.
@@ -721,10 +731,10 @@ int storj_bridge_create_bucket(storj_env_t *env,
  * @param[in] cb A function called with response when complete
  * @return A non-zero error value on failure and 0 on success.
  */
-int storj_bridge_delete_bucket(storj_env_t *env,
-                               const char *id,
-                               void *handle,
-                               uv_after_work_cb cb);
+STORJ_API int storj_bridge_delete_bucket(storj_env_t *env,
+                                         const char *id,
+                                         void *handle,
+                                         uv_after_work_cb cb);
 
 /**
  * @brief Get a info of specific bucket.
@@ -735,10 +745,10 @@ int storj_bridge_delete_bucket(storj_env_t *env,
  * @param[in] cb A function called with response when complete
  * @return A non-zero error value on failure and 0 on success.
  */
-int storj_bridge_get_bucket(storj_env_t *env,
-                            const char *id,
-                            void *handle,
-                            uv_after_work_cb cb);
+STORJ_API int storj_bridge_get_bucket(storj_env_t *env,
+                                      const char *id,
+                                      void *handle,
+                                      uv_after_work_cb cb);
 
 /**
  * @brief Get a list of all files in a bucket.
@@ -749,17 +759,17 @@ int storj_bridge_get_bucket(storj_env_t *env,
  * @param[in] cb A function called with response when complete
  * @return A non-zero error value on failure and 0 on success.
  */
-int storj_bridge_list_files(storj_env_t *env,
-                            const char *id,
-                            void *handle,
-                            uv_after_work_cb cb);
+STORJ_API int storj_bridge_list_files(storj_env_t *env,
+                                      const char *id,
+                                      void *handle,
+                                      uv_after_work_cb cb);
 
 /**
  * @brief Will free all structs for list files request
  *
  * @param[in] req - The work request from storj_bridge_list_files callback
  */
-void storj_free_list_files_request(list_files_request_t *req);
+STORJ_API void storj_free_list_files_request(list_files_request_t *req);
 
 /**
  * @brief Create a PUSH or PULL bucket token.
@@ -771,11 +781,11 @@ void storj_free_list_files_request(list_files_request_t *req);
  * @param[in] cb A function called with response when complete
  * @return A non-zero error value on failure and 0 on success.
  */
-int storj_bridge_create_bucket_token(storj_env_t *env,
-                                     const char *bucket_id,
-                                     storj_bucket_op_t operation,
-                                     void *handle,
-                                     uv_after_work_cb cb);
+STORJ_API int storj_bridge_create_bucket_token(storj_env_t *env,
+                                               const char *bucket_id,
+                                               storj_bucket_op_t operation,
+                                               void *handle,
+                                               uv_after_work_cb cb);
 
 /**
  * @brief Get pointers with locations to file shards.
@@ -787,11 +797,11 @@ int storj_bridge_create_bucket_token(storj_env_t *env,
  * @param[in] cb A function called with response when complete
  * @return A non-zero error value on failure and 0 on success.
  */
-int storj_bridge_get_file_pointers(storj_env_t *env,
-                                   const char *bucket_id,
-                                   const char *file_id,
-                                   void *handle,
-                                   uv_after_work_cb cb);
+STORJ_API int storj_bridge_get_file_pointers(storj_env_t *env,
+                                             const char *bucket_id,
+                                             const char *file_id,
+                                             void *handle,
+                                             uv_after_work_cb cb);
 
 /**
  * @brief Delete a file in a bucket.
@@ -803,11 +813,11 @@ int storj_bridge_get_file_pointers(storj_env_t *env,
  * @param[in] cb A function called with response when complete
  * @return A non-zero error value on failure and 0 on success.
  */
-int storj_bridge_delete_file(storj_env_t *env,
-                             const char *bucket_id,
-                             const char *file_id,
-                             void *handle,
-                             uv_after_work_cb cb);
+STORJ_API int storj_bridge_delete_file(storj_env_t *env,
+                                       const char *bucket_id,
+                                       const char *file_id,
+                                       void *handle,
+                                       uv_after_work_cb cb);
 
 /**
  * @brief Create a file frame
@@ -817,9 +827,9 @@ int storj_bridge_delete_file(storj_env_t *env,
  * @param[in] cb A function called with response when complete
  * @return A non-zero error value on failure and 0 on success.
  */
-int storj_bridge_create_frame(storj_env_t *env,
-                              void *handle,
-                              uv_after_work_cb cb);
+STORJ_API int storj_bridge_create_frame(storj_env_t *env,
+                                        void *handle,
+                                        uv_after_work_cb cb);
 
 /**
  * @brief List available file frames
@@ -829,9 +839,9 @@ int storj_bridge_create_frame(storj_env_t *env,
  * @param[in] cb A function called with response when complete
  * @return A non-zero error value on failure and 0 on success.
  */
-int storj_bridge_get_frames(storj_env_t *env,
-                            void *handle,
-                            uv_after_work_cb cb);
+STORJ_API int storj_bridge_get_frames(storj_env_t *env,
+                                      void *handle,
+                                      uv_after_work_cb cb);
 
 /**
  * @brief Get information for a file frame
@@ -842,10 +852,10 @@ int storj_bridge_get_frames(storj_env_t *env,
  * @param[in] cb A function called with response when complete
  * @return A non-zero error value on failure and 0 on success.
  */
-int storj_bridge_get_frame(storj_env_t *env,
-                           const char *frame_id,
-                           void *handle,
-                           uv_after_work_cb cb);
+ STORJ_API int storj_bridge_get_frame(storj_env_t *env,
+                                      const char *frame_id,
+                                      void *handle,
+                                      uv_after_work_cb cb);
 
 /**
  * @brief Delete a file frame
@@ -856,10 +866,10 @@ int storj_bridge_get_frame(storj_env_t *env,
  * @param[in] cb A function called with response when complete
  * @return A non-zero error value on failure and 0 on success.
  */
-int storj_bridge_delete_frame(storj_env_t *env,
-                              const char *frame_id,
-                              void *handle,
-                              uv_after_work_cb cb);
+STORJ_API int storj_bridge_delete_frame(storj_env_t *env,
+                                        const char *frame_id,
+                                        void *handle,
+                                        uv_after_work_cb cb);
 
 /**
  * @brief Get metadata for a file
@@ -871,11 +881,11 @@ int storj_bridge_delete_frame(storj_env_t *env,
  * @param[in] cb A function called with response when complete
  * @return A non-zero error value on failure and 0 on success.
  */
-int storj_bridge_get_file_info(storj_env_t *env,
-                               const char *bucket_id,
-                               const char *file_id,
-                               void *handle,
-                               uv_after_work_cb cb);
+STORJ_API int storj_bridge_get_file_info(storj_env_t *env,
+                                         const char *bucket_id,
+                                         const char *file_id,
+                                         void *handle,
+                                         uv_after_work_cb cb);
 
 /**
  * @brief Get mirror data for a file
@@ -887,11 +897,11 @@ int storj_bridge_get_file_info(storj_env_t *env,
  * @param[in] cb A function called with response when complete
  * @return A non-zero error value on failure and 0 on success.
  */
-int storj_bridge_list_mirrors(storj_env_t *env,
-                              const char *bucket_id,
-                              const char *file_id,
-                              void *handle,
-                              uv_after_work_cb cb);
+STORJ_API int storj_bridge_list_mirrors(storj_env_t *env,
+                                        const char *bucket_id,
+                                        const char *file_id,
+                                        void *handle,
+                                        uv_after_work_cb cb);
 
 /**
  * @brief Will cancel an upload
@@ -899,7 +909,7 @@ int storj_bridge_list_mirrors(storj_env_t *env,
  * @param[in] state A pointer to the the upload state
  * @return A non-zero error value on failure and 0 on success.
  */
-int storj_bridge_store_file_cancel(storj_upload_state_t *state);
+STORJ_API int storj_bridge_store_file_cancel(storj_upload_state_t *state);
 
 /**
  * @brief Upload a file
@@ -912,12 +922,12 @@ int storj_bridge_store_file_cancel(storj_upload_state_t *state);
  * @param[in] finished_cb Function called when download finished
  * @return A non-zero error value on failure and 0 on success.
  */
-int storj_bridge_store_file(storj_env_t *env,
-                            storj_upload_state_t *state,
-                            storj_upload_opts_t *opts,
-                            void *handle,
-                            storj_progress_cb progress_cb,
-                            storj_finished_upload_cb finished_cb);
+STORJ_API int storj_bridge_store_file(storj_env_t *env,
+                                      storj_upload_state_t *state,
+                                      storj_upload_opts_t *opts,
+                                      void *handle,
+                                      storj_progress_cb progress_cb,
+                                      storj_finished_upload_cb finished_cb);
 
 
 /**
@@ -926,7 +936,7 @@ int storj_bridge_store_file(storj_env_t *env,
  * @param[in] state A pointer to the the download state
  * @return A non-zero error value on failure and 0 on success.
  */
-int storj_bridge_resolve_file_cancel(storj_download_state_t *state);
+STORJ_API int storj_bridge_resolve_file_cancel(storj_download_state_t *state);
 
 /**
  * @brief Download a file
@@ -941,14 +951,14 @@ int storj_bridge_resolve_file_cancel(storj_download_state_t *state);
  * @param[in] finished_cb Function called when download finished
  * @return A non-zero error value on failure and 0 on success.
  */
-int storj_bridge_resolve_file(storj_env_t *env,
-                              storj_download_state_t *state,
-                              const char *bucket_id,
-                              const char *file_id,
-                              FILE *destination,
-                              void *handle,
-                              storj_progress_cb progress_cb,
-                              storj_finished_download_cb finished_cb);
+STORJ_API int storj_bridge_resolve_file(storj_env_t *env,
+                                        storj_download_state_t *state,
+                                        const char *bucket_id,
+                                        const char *file_id,
+                                        FILE *destination,
+                                        void *handle,
+                                        storj_progress_cb progress_cb,
+                                        storj_finished_download_cb finished_cb);
 
 /**
  * @brief Register a user
@@ -960,11 +970,11 @@ int storj_bridge_resolve_file(storj_env_t *env,
  * @param[in] cb A function called with response when complete
  * @return A non-zero error value on failure and 0 on success.
  */
-int storj_bridge_register(storj_env_t *env,
-                          const char *email,
-                          const char *password,
-                          void *handle,
-                          uv_after_work_cb cb);
+STORJ_API int storj_bridge_register(storj_env_t *env,
+                                    const char *email,
+                                    const char *password,
+                                    void *handle,
+                                    uv_after_work_cb cb);
 
 static inline char separator()
 {

--- a/src/uploader.c
+++ b/src/uploader.c
@@ -2618,7 +2618,7 @@ char *create_tmp_name(storj_upload_state_t *state, char *extension)
     return path;
 }
 
-int storj_bridge_store_file_cancel(storj_upload_state_t *state)
+STORJ_API int storj_bridge_store_file_cancel(storj_upload_state_t *state)
 {
     if (state->canceled) {
         return 0;
@@ -2641,7 +2641,7 @@ int storj_bridge_store_file_cancel(storj_upload_state_t *state)
     return 0;
 }
 
-int storj_bridge_store_file(storj_env_t *env,
+STORJ_API int storj_bridge_store_file(storj_env_t *env,
                             storj_upload_state_t *state,
                             storj_upload_opts_t *opts,
                             void *handle,

--- a/src/utils.c
+++ b/src/utils.c
@@ -85,7 +85,7 @@ void random_buffer(uint8_t *buf, size_t len)
     static FILE *frand = NULL;
 #ifdef _WIN32
     HCRYPTPROV hProvider;
-    int ret = CryptAcquireContextW(&hProvider, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT);
+    int ret = CryptAcquireContext(&hProvider, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT);
     assert(ret);
     ret = CryptGenRandom(hProvider, len, buf);
     assert(ret);

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,7 +1,14 @@
 noinst_PROGRAMS = tests tests_rs
 tests_SOURCES = mockbridge.c mockfarmer.c tests.c storjtests.h $(top_builddir)/src/storj.h mockbridge.json.h mockbridgeinfo.json.h
 tests_LDADD = $(top_builddir)/src/libstorj.la
-tests_LDFLAGS = -Wall -g -static -lmicrohttpd
+tests_LDFLAGS = -Wall -g
+
+if BUILD_STORJ_DLL
+tests_LDFLAGS += -lmicrohttpd $(top_builddir)/src/.libs/rs.o $(top_builddir)/src/.libs/bip39.o $(top_builddir)/src/.libs/crypto.o $(top_builddir)/src/.libs/utils.o
+else
+tests_LDFLAGS += -static -lmicrohttpd
+endif
+
 tests_rs_SOURCES = tests_rs.c
 tests_rs_LDFLAGS = -Wall -g
 TESTS = tests tests_rs


### PR DESCRIPTION
Added support to build libstorj as shared library (dll) for windows and link the cli against it.
Build instructions are included in the Readme.

Existing builds should not be affected. ARM and MacOS couldn't be tested due to a lack of hardware.

