### PR TITLE
Ensure erasure and index are properly initialized

### DIFF
--- a/src/storj.c
+++ b/src/storj.c
@@ -232,6 +232,8 @@ static void list_files_request_worker(uv_work_t *work)
         file->created = json_object_get_string(created);
         file->mimetype = json_object_get_string(mimetype);
         file->size = json_object_get_int64(size);
+        file->erasure = NULL;
+        file->index = NULL;
         file->hmac = NULL; // TODO though this value is not needed here
         file->id = json_object_get_string(id);
         file->decrypted = false;


### PR DESCRIPTION
Otherwise they point to an arbitrary memory address and SIGSEGV is generated when I try to convert them to a Java string object.