### PR TITLE
Compile with fPIC

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ cd ./depends
 make HOST="x86_64-pc-linux-gnu"
 ```
 
-Configure command for libstorj-c:
+Configure command for libstorj-c for static and shared libraries:
 ```
-PKG_CONFIG_LIBDIR="$(pwd)/depends/build/x86_64-pc-linux-gnu/lib/pkgconfig" CFLAGS="-I$(pwd)/depends/build/x86_64-pc-linux-gnu/include -L$(pwd)/depends/build/x86_64-pc-linux-gnu/lib -static" ./configure --host=x86_64-pc-linux-gnu --enable-static --disable-shared --prefix=$(pwd)/depends/build/x86_64-pc-linux-gnu
+PKG_CONFIG_LIBDIR="$(pwd)/depends/build/x86_64-pc-linux-gnu/lib/pkgconfig" CFLAGS="-I$(pwd)/depends/build/x86_64-pc-linux-gnu/include -L$(pwd)/depends/build/x86_64-pc-linux-gnu/lib -static" ./configure --host=x86_64-pc-linux-gnu --with-pic --enable-static --enable-shared --prefix=$(pwd)/depends/build/x86_64-pc-linux-gnu
 ```
 
 **32-bit GNU/linux**
@@ -169,7 +169,7 @@ make HOST="i686-pc-linux-gnu"
 
 Configure command for libstorj-c:
 ```
-PKG_CONFIG_LIBDIR="$(pwd)/depends/build/i686-pc-linux-gnu/lib/pkgconfig" CFLAGS="-I$(pwd)/depends/build/i686-pc-linux-gnu/include -L$(pwd)/depends/build/i686-pc-linux-gnu/lib -static -m32" LDFLAGS="-m32" ./configure --host=i686-pc-linux-gnu --enable-static --disable-shared --prefix=$(pwd)/depends/build/i686-pc-linux-gnu
+PKG_CONFIG_LIBDIR="$(pwd)/depends/build/i686-pc-linux-gnu/lib/pkgconfig" CFLAGS="-I$(pwd)/depends/build/i686-pc-linux-gnu/include -L$(pwd)/depends/build/i686-pc-linux-gnu/lib -static -m32" LDFLAGS="-m32" ./configure --host=i686-pc-linux-gnu --with-pic --enable-static --enable-shared --prefix=$(pwd)/depends/build/i686-pc-linux-gnu
 ```
 
 **Mac OSX**

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_INIT([libstorj],[1.0.1])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([build-aux/m4])
 AM_INIT_AUTOMAKE([foreign])
-LT_INIT([win32-dll])
+LT_INIT([shared static win32-dll])
 
 AC_PATH_PROG(HEXDUMP,hexdump)
 

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -24,7 +24,7 @@ ifeq ($(host_os),)
 host_os=$(full_host_os)
 endif
 
-config_lib_type=--enable-static --disable-shared
+config_lib_type=--enable-static --disable-shared --with-pic
 
 # mingw dll build
 ifeq ($(HOST), x86_64-w64-mingw32)

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -92,7 +92,7 @@ define build_source
 	echo "====================================\n\n" && \
 	export PATH="$(TOOLCHAIN_BUILD_DIR)bin:${PATH}" && \
 	if test -f "./autogen.sh"; then ./autogen.sh; fi && \
-	$(build_env) $($(1)_config_env) ./configure --host="$(HOST)" $($(1)_config_opts) $(config_lib_type) --prefix=$(PREFIX_DIR) || exit && \
+	$(build_env) $($(1)_config_env) ./configure --host="$(HOST)" $($(1)_config_opts) $(config_lib_type) --with-pic --prefix=$(PREFIX_DIR) || exit && \
 	make || exit && \
 	make install || exit && \
 	cd "$(CURDIR)"

--- a/depends/packages/nettle.mk
+++ b/depends/packages/nettle.mk
@@ -5,7 +5,7 @@ $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=46942627d5d0ca11720fec18d81fc38f7ef837ea4197c1f630e71ce0d470b11e
 
 # default settings
-$(package)_config_env_default=PKG_CONFIG_LIBDIR="$(PREFIX_DIR)/lib/pkgconfig" CFLAGS="-I$(PREFIX_DIR)include -L$(PREFIX_DIR)lib"
+$(package)_config_env_default=PKG_CONFIG_LIBDIR="$(PREFIX_DIR)/lib/pkgconfig" CFLAGS="-I$(PREFIX_DIR)include -L$(PREFIX_DIR)lib -fPIC"
 $(package)_config_opts_default=--enable-pic
 
 # mingw specific settings

--- a/depends/packages/nettle.mk
+++ b/depends/packages/nettle.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=46942627d5d0ca11720fec18d81fc38f7ef837ea4197c1f630e71ce0d
 
 # default settings
 $(package)_config_env_default=PKG_CONFIG_LIBDIR="$(PREFIX_DIR)/lib/pkgconfig" CFLAGS="-I$(PREFIX_DIR)include -L$(PREFIX_DIR)lib"
-$(package)_config_opts_default=
+$(package)_config_opts_default=--enable-pic
 
 # mingw specific settings
 $(package)_config_env_mingw32=PKG_CONFIG_LIBDIR="$(PREFIX_DIR)/lib/pkgconfig" CFLAGS="-I$(PREFIX_DIR)include -L$(PREFIX_DIR)lib" -static

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,7 +9,7 @@ include_HEADERS = storj.h
 
 bin_PROGRAMS = storj
 storj_SOURCES = cli.c storj.h
-storj_LDADD = libstorj.la
+storj_LDADD = libstorj.la -lcurl -lnettle -ljson-c -luv -lm
 if BUILD_STORJ_DLL
 storj_LDFLAGS = -Wall
 else

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,11 +7,11 @@ libstorj_la_LDFLAGS += -no-undefined
 endif
 include_HEADERS = storj.h
 
-bin_PROGRAMS = storj
-storj_SOURCES = cli.c storj.h
-storj_LDADD = libstorj.la
-if BUILD_STORJ_DLL
-storj_LDFLAGS = -Wall
-else
-storj_LDFLAGS = -Wall -static
-endif
+# bin_PROGRAMS = storj
+# storj_SOURCES = cli.c storj.h
+# storj_LDADD = libstorj.la
+# if BUILD_STORJ_DLL
+# storj_LDFLAGS = -Wall
+# else
+# storj_LDFLAGS = -Wall -static
+# endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,11 +7,11 @@ libstorj_la_LDFLAGS += -no-undefined
 endif
 include_HEADERS = storj.h
 
-# bin_PROGRAMS = storj
-# storj_SOURCES = cli.c storj.h
-# storj_LDADD = libstorj.la
-# if BUILD_STORJ_DLL
-# storj_LDFLAGS = -Wall
-# else
-# storj_LDFLAGS = -Wall -static
-# endif
+bin_PROGRAMS = storj
+storj_SOURCES = cli.c storj.h
+storj_LDADD = libstorj.la
+if BUILD_STORJ_DLL
+storj_LDFLAGS = -Wall
+else
+storj_LDFLAGS = -Wall -static
+endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,7 +9,7 @@ include_HEADERS = storj.h
 
 bin_PROGRAMS = storj
 storj_SOURCES = cli.c storj.h
-storj_LDADD = libstorj.la -lcurl -lnettle -ljson-c -luv -lm
+storj_LDADD = libstorj.la
 if BUILD_STORJ_DLL
 storj_LDFLAGS = -Wall
 else


### PR DESCRIPTION
Was able to get static build with ([for linking from node-libstorj](https://github.com/Storj/node-libstorj/pull/30)) after running `make` in `./depends`:
```
PKG_CONFIG_LIBDIR="$(pwd)/depends/build/x86_64-pc-linux-gnu/lib/pkgconfig" CFLAGS="-I$(pwd)/depends/build/x86_64-pc-linux-gnu/include -L$(pwd)/depends/build/x86_64-pc-linux-gnu/lib-static" ./configure --host=x86_64-pc-linux-gnu --with-pic --enable-static --disable-shared --prefix=$(pwd)/release/x86_64-pc-linux-gnu
```
---
Was able to get `.so` build at commit 730ed0e543e2f543175e20d920886b0672076fe8 with:
```
PKG_CONFIG_LIBDIR="$(pwd)/depends/build/x86_64-pc-linux-gnu/lib/pkgconfig" CFLAGS="-I$(pwd)/depends/build/x86_64-pc-linux-gnu/include -L$(pwd)/depends/build/x86_64-pc-linux-gnu/lib" ./configure --host=x86_64-pc-linux-gnu --disable-static --enable-shared --prefix=$(pwd)/release/x86_64-pc-linux-gnu
```

Reference: https://github.com/braydonf/autotools-boilerplate
Variation from: https://github.com/Storj/libstorj/pull/359