### PR TITLE
Updates for bindings

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -509,24 +509,18 @@ static int download_file(storj_env_t *env, char *bucket_id,
     uv_signal_init(env->loop, sig);
     uv_signal_start(sig, download_signal_handler, SIGINT);
 
-    storj_download_state_t *state = malloc(sizeof(storj_download_state_t));
-    if (!state) {
-        return 1;
-    }
-
-    sig->data = state;
-
     storj_progress_cb progress_cb = (storj_progress_cb)noop;
     if (path && env->log_options->level == 0) {
         progress_cb = file_progress;
     }
 
-    int status = storj_bridge_resolve_file(env, state, bucket_id,
-                                           file_id, fd, NULL,
-                                           progress_cb,
-                                           download_file_complete);
+    storj_download_state_t *state = storj_bridge_resolve_file(env, bucket_id,
+                                                              file_id, fd, NULL,
+                                                              progress_cb,
+                                                              download_file_complete);
+    sig->data = state;
 
-    return status;
+    return state->error_status;
 }
 
 static void list_mirrors_callback(uv_work_t *work_req, int status)

--- a/src/cli.c
+++ b/src/cli.c
@@ -414,26 +414,22 @@ static int upload_file(storj_env_t *env, char *bucket_id, const char *file_path)
     uv_signal_init(env->loop, sig);
     uv_signal_start(sig, upload_signal_handler, SIGINT);
 
-    storj_upload_state_t *state = malloc(sizeof(storj_upload_state_t));
-    if (!state) {
-        return 1;
-    }
 
-    sig->data = state;
 
     storj_progress_cb progress_cb = (storj_progress_cb)noop;
     if (env->log_options->level == 0) {
         progress_cb = file_progress;
     }
 
-    int status = storj_bridge_store_file(env,
-                                         state,
-                                         &upload_opts,
-                                         NULL,
-                                         progress_cb,
-                                         upload_file_complete);
+    storj_upload_state_t *state = storj_bridge_store_file(env,
+                                                          &upload_opts,
+                                                          NULL,
+                                                          progress_cb,
+                                                          upload_file_complete);
 
-    return status;
+    sig->data = state;
+
+    return state->error_status;
 }
 
 static void download_file_complete(int status, FILE *fd, void *handle)

--- a/src/cli.c
+++ b/src/cli.c
@@ -427,6 +427,10 @@ static int upload_file(storj_env_t *env, char *bucket_id, const char *file_path)
                                                           progress_cb,
                                                           upload_file_complete);
 
+    if (!state) {
+        return 1;
+    }
+
     sig->data = state;
 
     return state->error_status;
@@ -514,6 +518,9 @@ static int download_file(storj_env_t *env, char *bucket_id,
                                                               file_id, fd, NULL,
                                                               progress_cb,
                                                               download_file_complete);
+    if (!state) {
+        return 1;
+    }
     sig->data = state;
 
     return state->error_status;

--- a/src/downloader.c
+++ b/src/downloader.c
@@ -1866,15 +1866,19 @@ STORJ_API int storj_bridge_resolve_file_cancel(storj_download_state_t *state)
     return 0;
 }
 
-STORJ_API int storj_bridge_resolve_file(storj_env_t *env,
-                              storj_download_state_t *state,
-                              const char *bucket_id,
-                              const char *file_id,
-                              FILE *destination,
-                              void *handle,
-                              storj_progress_cb progress_cb,
-                              storj_finished_download_cb finished_cb)
+STORJ_API storj_download_state_t *storj_bridge_resolve_file(storj_env_t *env,
+                                                            const char *bucket_id,
+                                                            const char *file_id,
+                                                            FILE *destination,
+                                                            void *handle,
+                                                            storj_progress_cb progress_cb,
+                                                            storj_finished_download_cb finished_cb)
 {
+    storj_download_state_t *state = malloc(sizeof(storj_download_state_t));
+    if (!state) {
+        return NULL;
+    }
+
     // setup download state
     state->total_bytes = 0;
     state->info = NULL;
@@ -1915,5 +1919,5 @@ STORJ_API int storj_bridge_resolve_file(storj_env_t *env,
     // start download
     queue_next_work(state);
 
-    return state->error_status;
+    return state;
 }

--- a/src/storj.h
+++ b/src/storj.h
@@ -976,14 +976,13 @@ STORJ_API int storj_bridge_resolve_file_cancel(storj_download_state_t *state);
  * @param[in] finished_cb Function called when download finished
  * @return A non-zero error value on failure and 0 on success.
  */
-STORJ_API int storj_bridge_resolve_file(storj_env_t *env,
-                                        storj_download_state_t *state,
-                                        const char *bucket_id,
-                                        const char *file_id,
-                                        FILE *destination,
-                                        void *handle,
-                                        storj_progress_cb progress_cb,
-                                        storj_finished_download_cb finished_cb);
+STORJ_API storj_download_state_t *storj_bridge_resolve_file(storj_env_t *env,
+                                                            const char *bucket_id,
+                                                            const char *file_id,
+                                                            FILE *destination,
+                                                            void *handle,
+                                                            storj_progress_cb progress_cb,
+                                                            storj_finished_download_cb finished_cb);
 
 /**
  * @brief Register a user

--- a/src/storj.h
+++ b/src/storj.h
@@ -947,13 +947,11 @@ STORJ_API int storj_bridge_store_file_cancel(storj_upload_state_t *state);
  * @param[in] finished_cb Function called when download finished
  * @return A non-zero error value on failure and 0 on success.
  */
-STORJ_API int storj_bridge_store_file(storj_env_t *env,
-                                      storj_upload_state_t *state,
-                                      storj_upload_opts_t *opts,
-                                      void *handle,
-                                      storj_progress_cb progress_cb,
-                                      storj_finished_upload_cb finished_cb);
-
+STORJ_API storj_upload_state_t *storj_bridge_store_file(storj_env_t *env,
+                                                        storj_upload_opts_t *opts,
+                                                        void *handle,
+                                                        storj_progress_cb progress_cb,
+                                                        storj_finished_upload_cb finished_cb);
 
 /**
  * @brief Will cancel a download

--- a/src/uploader.c
+++ b/src/uploader.c
@@ -2641,8 +2641,7 @@ STORJ_API int storj_bridge_store_file_cancel(storj_upload_state_t *state)
     return 0;
 }
 
-STORJ_API int storj_bridge_store_file(storj_env_t *env,
-                            storj_upload_state_t *state,
+STORJ_API storj_upload_state_t *storj_bridge_store_file(storj_env_t *env,
                             storj_upload_opts_t *opts,
                             void *handle,
                             storj_progress_cb progress_cb,
@@ -2650,7 +2649,12 @@ STORJ_API int storj_bridge_store_file(storj_env_t *env,
 {
     if (!opts->fd) {
         env->log->error(env->log_options, handle, "Invalid File descriptor");
-        return 1;
+        return NULL;
+    }
+
+    storj_upload_state_t *state = malloc(sizeof(storj_upload_state_t));
+    if (!state) {
+        return NULL;
     }
 
     state->env = env;
@@ -2722,6 +2726,11 @@ STORJ_API int storj_bridge_store_file(storj_env_t *env,
     work->data = state;
 
     state->pending_work_count += 1;
-    return uv_queue_work(env->loop, (uv_work_t*) work,
-                         prepare_upload_state, begin_work_queue);
+
+    int status = uv_queue_work(env->loop, (uv_work_t*) work,
+                               prepare_upload_state, begin_work_queue);
+    if (status) {
+        state->error_status = STORJ_QUEUE_ERROR;
+    }
+    return state;
 }

--- a/src/uploader.c
+++ b/src/uploader.c
@@ -964,7 +964,8 @@ static void after_push_frame(uv_work_t *work, int status)
             p->farmer_node_id
         );
 
-    } else if (state->shard[req->shard_meta_index].push_frame_request_count == 6) {
+    } else if (state->shard[req->shard_meta_index].push_frame_request_count ==
+               STORJ_MAX_PUSH_FRAME_COUNT) {
         state->error_status = STORJ_BRIDGE_OFFER_ERROR;
     } else {
         state->shard[req->shard_meta_index].progress = AWAITING_PUSH_FRAME;

--- a/src/uploader.h
+++ b/src/uploader.h
@@ -14,6 +14,7 @@
 
 #define STORJ_NULL -1
 #define STORJ_MAX_REPORT_TRIES 2
+#define STORJ_MAX_PUSH_FRAME_COUNT 6
 
 typedef enum {
     CANCELED = 0,

--- a/test/tests.c
+++ b/test/tests.c
@@ -529,15 +529,12 @@ int test_upload()
         .rs = true
     };
 
-    storj_upload_state_t *state = malloc(sizeof(storj_upload_state_t));
-
-    int status = storj_bridge_store_file(env,
-                                         state,
-                                         &upload_opts,
-                                         NULL,
-                                         check_store_file_progress,
-                                         check_store_file);
-    assert(status == 0);
+    storj_upload_state_t *state = storj_bridge_store_file(env,
+                                                          &upload_opts,
+                                                          NULL,
+                                                          check_store_file_progress,
+                                                          check_store_file);
+    assert(state->error_status == 0);
 
     // run all queued events
 
@@ -578,21 +575,19 @@ int test_upload_cancel()
         .fd = fopen(file, "r")
     };
 
-    storj_upload_state_t *state = malloc(sizeof(storj_upload_state_t));
-
-    int status = storj_bridge_store_file(env,
-                                         state,
-                                         &upload_opts,
-                                         NULL,
-                                         check_store_file_progress,
-                                         check_store_file_cancel);
-    assert(status == 0);
+    storj_upload_state_t *state = storj_bridge_store_file(env,
+                                                          &upload_opts,
+                                                          NULL,
+                                                          check_store_file_progress,
+                                                          check_store_file_cancel);
+    assert(state->error_status == 0);
 
 
     // process the loop one at a time so that we can do other things while
     // the loop is processing, such as cancel the download
     int count = 0;
     bool more;
+    int status = 0;
     do {
         more = uv_run(env->loop, UV_RUN_ONCE);
         if (more == false) {

--- a/test/tests.c
+++ b/test/tests.c
@@ -534,10 +534,11 @@ int test_upload()
                                                           NULL,
                                                           check_store_file_progress,
                                                           check_store_file);
-    assert(state->error_status == 0);
+    if (!state || state->error_status != 0) {
+        return 1;
+    }
 
     // run all queued events
-
     if (uv_run(env->loop, UV_RUN_DEFAULT)) {
         return 1;
     }
@@ -580,8 +581,9 @@ int test_upload_cancel()
                                                           NULL,
                                                           check_store_file_progress,
                                                           check_store_file_cancel);
-    assert(state->error_status == 0);
-
+    if (!state || state->error_status != 0) {
+        return 1;
+    }
 
     // process the loop one at a time so that we can do other things while
     // the loop is processing, such as cancel the download
@@ -639,9 +641,11 @@ int test_download()
                                                               check_resolve_file_progress,
                                                               check_resolve_file);
 
-    free(download_file);
+    if (!state || state->error_status != 0) {
+        return 1;
+    }
 
-    assert(state->error_status == 0);
+    free(download_file);
 
     if (uv_run(env->loop, UV_RUN_DEFAULT)) {
         return 1;
@@ -679,7 +683,9 @@ int test_download_cancel()
                                                               check_resolve_file_progress,
                                                               check_resolve_file_cancel);
 
-    assert(state->error_status == 0);
+    if (!state || state->error_status != 0) {
+        return 1;
+    }
 
     // process the loop one at a time so that we can do other things while
     // the loop is processing, such as cancel the download

--- a/test/tests.c
+++ b/test/tests.c
@@ -636,20 +636,17 @@ int test_download()
     char *bucket_id = "368be0816766b28fd5f43af5";
     char *file_id = "998960317b6725a3f8080c2b";
 
-    storj_download_state_t *state = malloc(sizeof(storj_download_state_t));
-
-    int status = storj_bridge_resolve_file(env,
-                                           state,
-                                           bucket_id,
-                                           file_id,
-                                           download_fp,
-                                           NULL,
-                                           check_resolve_file_progress,
-                                           check_resolve_file);
+    storj_download_state_t *state = storj_bridge_resolve_file(env,
+                                                              bucket_id,
+                                                              file_id,
+                                                              download_fp,
+                                                              NULL,
+                                                              check_resolve_file_progress,
+                                                              check_resolve_file);
 
     free(download_file);
 
-    assert(status == 0);
+    assert(state->error_status == 0);
 
     if (uv_run(env->loop, UV_RUN_DEFAULT)) {
         return 1;
@@ -679,23 +676,21 @@ int test_download_cancel()
     char *bucket_id = "368be0816766b28fd5f43af5";
     char *file_id = "998960317b6725a3f8080c2b";
 
-    storj_download_state_t *state = malloc(sizeof(storj_download_state_t));
+    storj_download_state_t *state = storj_bridge_resolve_file(env,
+                                                              bucket_id,
+                                                              file_id,
+                                                              download_fp,
+                                                              NULL,
+                                                              check_resolve_file_progress,
+                                                              check_resolve_file_cancel);
 
-    int status = storj_bridge_resolve_file(env,
-                                           state,
-                                           bucket_id,
-                                           file_id,
-                                           download_fp,
-                                           NULL,
-                                           check_resolve_file_progress,
-                                           check_resolve_file_cancel);
-
-    assert(status == 0);
+    assert(state->error_status == 0);
 
     // process the loop one at a time so that we can do other things while
     // the loop is processing, such as cancel the download
     int count = 0;
     bool more;
+    int status = 0;
     do {
         more = uv_run(env->loop, UV_RUN_ONCE);
         if (more == false) {


### PR DESCRIPTION
Changes signatures for `storj_bridge_revolve_file` and `storj_bridge_store_file` to allocate upload and download state and return a pointer to it.

Alternative to solve issue raised in https://github.com/Storj/libstorj/pull/391