### PR TITLE
Resolve bucket->created in create_bucket_request_worker

### DIFF
--- a/src/storj.c
+++ b/src/storj.c
@@ -72,10 +72,14 @@ static void create_bucket_request_worker(uv_work_t *work)
         req->bucket = malloc(sizeof(storj_bucket_meta_t));
 
         struct json_object *id;
+        struct json_object *created;
+
         json_object_object_get_ex(req->response, "id", &id);
+        json_object_object_get_ex(req->response, "created", &created);
 
         req->bucket->id = json_object_get_string(id);
         req->bucket->name = req->bucket_name;
+        req->bucket->created = json_object_get_string(created);
         req->bucket->decrypted = true;
     }
 


### PR DESCRIPTION
The `bucket->created` property was not set and left uninitialized in the
`create_bucket_request_worker` function. Left as uninitialized pointer
it points to an arbitrary part of the memory and causes random issues to
clients trying to access it.