### PR TITLE
Avoid double call to `json_object_put`

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -844,7 +844,6 @@ static void list_files_callback(uv_work_t *work_req, int status)
     }
 
 cleanup:
-    json_object_put(req->response);
     storj_free_list_files_request(req);
     free(work_req);
     exit(ret_status);
@@ -908,7 +907,6 @@ static void get_buckets_callback(uv_work_t *work_req, int status)
                bucket->created, bucket->name);
     }
 
-    json_object_put(req->response);
     storj_free_get_buckets_request(req);
     free(work_req);
 }

--- a/src/storj.c
+++ b/src/storj.c
@@ -1198,7 +1198,9 @@ STORJ_API int storj_bridge_get_buckets(storj_env_t *env, void *handle, uv_after_
 
 STORJ_API void storj_free_get_buckets_request(get_buckets_request_t *req)
 {
-    json_object_put(req->response);
+    if (req->response) {
+        json_object_put(req->response);
+    }
     if (req->buckets && req->total_buckets > 0) {
         for (int i = 0; i < req->total_buckets; i++) {
             free((char *)req->buckets[i].name);
@@ -1279,7 +1281,9 @@ STORJ_API int storj_bridge_get_bucket(storj_env_t *env,
 
 STORJ_API void storj_free_get_bucket_request(get_bucket_request_t *req)
 {
-    json_object_put(req->response);
+    if (req->response) {
+        json_object_put(req->response);
+    }
     free(req->path);
     if (req->bucket) {
         free((char *)req->bucket->name);
@@ -1318,7 +1322,9 @@ STORJ_API int storj_bridge_list_files(storj_env_t *env,
 
 STORJ_API void storj_free_list_files_request(list_files_request_t *req)
 {
-    json_object_put(req->response);
+    if (req->response) {
+        json_object_put(req->response);
+    }
     free(req->path);
     if (req->files && req->total_files > 0) {
         for (int i = 0; i < req->total_files; i++) {

--- a/src/uploader.c
+++ b/src/uploader.c
@@ -2133,7 +2133,6 @@ static void verify_bucket_id_callback(uv_work_t *work_req, int status)
 clean_variables:
     queue_next_work(state);
 
-    json_object_put(req->response);
     storj_free_get_bucket_request(req);
     free(work_req);
 }


### PR DESCRIPTION
Double calls to `json_object_put` may occasionally cause EXCEPTION_ACCESS_VIOLATION (0xc0000005) crash. I have experienced this several times on Windows.