### PR TITLE
Provide file metadata in storj_finished_upload_cb, not only file id

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -352,7 +352,7 @@ static void file_progress(double progress,
     fflush(stdout);
 }
 
-static void upload_file_complete(int status, char *file_id, void *handle)
+static void upload_file_complete(int status, storj_file_meta_t *file, void *handle)
 {
     printf("\n");
     if (status != 0) {
@@ -360,9 +360,9 @@ static void upload_file_complete(int status, char *file_id, void *handle)
         exit(status);
     }
 
-    printf("Upload Success! File ID: %s\n", file_id);
+    printf("Upload Success! File ID: %s\n", file->id);
 
-    free(file_id);
+    storj_free_uploaded_file_info(file);
 
     exit(0);
 }

--- a/src/storj.h
+++ b/src/storj.h
@@ -375,7 +375,7 @@ typedef void (*storj_finished_download_cb)(int status, FILE *fd, void *handle);
 
 /** @brief A function signature for an upload complete callback
  */
-typedef void (*storj_finished_upload_cb)(int error_status, char *file_id, void *handle);
+typedef void (*storj_finished_upload_cb)(int error_status, storj_file_meta_t *file, void *handle);
 
 /** @brief A structure that represents a pointer to a shard
  *
@@ -503,7 +503,7 @@ typedef struct {
     uint32_t shard_concurrency;
     const char *index;
     const char *file_name;
-    char *file_id;
+    storj_file_meta_t *info;
     const char *encrypted_file_name;
     FILE *original_file;
     uint64_t file_size;
@@ -978,6 +978,13 @@ STORJ_API storj_upload_state_t *storj_bridge_store_file(storj_env_t *env,
                                                         void *handle,
                                                         storj_progress_cb progress_cb,
                                                         storj_finished_upload_cb finished_cb);
+
+/**
+ * @brief Will free the file info struct passed to the upload finished callback
+ *
+ * @param[in] file - The storj_file_meta_t struct from storj_finished_upload_cb callback
+ */
+STORJ_API void storj_free_uploaded_file_info(storj_file_meta_t *file);
 
 /**
  * @brief Will cancel a download

--- a/test/tests.c
+++ b/test/tests.c
@@ -283,11 +283,11 @@ void check_store_file_progress(double progress,
     }
 }
 
-void check_store_file(int error_code, char *file_id, void *handle)
+void check_store_file(int error_code, storj_file_meta_t *file, void *handle)
 {
     assert(handle == NULL);
     if (error_code == 0) {
-        if (strcmp(file_id, "85fb0ed00de1196dc22e0f6d") == 0 ) {
+        if (strcmp(file->id, "85fb0ed00de1196dc22e0f6d") == 0 ) {
             pass("storj_bridge_store_file");
         } else {
             fail("storj_bridge_store_file(0)");
@@ -297,10 +297,10 @@ void check_store_file(int error_code, char *file_id, void *handle)
         printf("\t\tERROR:   %s\n", storj_strerror(error_code));
     }
 
-    free(file_id);
+    storj_free_uploaded_file_info(file);
 }
 
-void check_store_file_cancel(int error_code, char *file_id, void *handle)
+void check_store_file_cancel(int error_code, storj_file_meta_t *file, void *handle)
 {
     assert(handle == NULL);
     if (error_code == STORJ_TRANSFER_CANCELED) {
@@ -310,7 +310,7 @@ void check_store_file_cancel(int error_code, char *file_id, void *handle)
         printf("\t\tERROR:   %s\n", storj_strerror(error_code));
     }
 
-    free(file_id);
+    storj_free_uploaded_file_info(file);
 }
 
 void check_delete_file(uv_work_t *work_req, int status)

--- a/test/tests.c
+++ b/test/tests.c
@@ -287,7 +287,7 @@ void check_store_file(int error_code, storj_file_meta_t *file, void *handle)
 {
     assert(handle == NULL);
     if (error_code == 0) {
-        if (strcmp(file->id, "85fb0ed00de1196dc22e0f6d") == 0 ) {
+        if (file && strcmp(file->id, "85fb0ed00de1196dc22e0f6d") == 0 ) {
             pass("storj_bridge_store_file");
         } else {
             fail("storj_bridge_store_file(0)");


### PR DESCRIPTION
The bridge API returns complete file metadata for uploaded files, but the `storj_finished_upload_cb` callback passed only the file id to libstorj clients. Thus, clients needed to execute an additional call to the bridge for retrieving metadata of interest like Created Time or HMAC. This causes unnecessary complexity and latency for clients and unnecessary load to the bridge.