### PR TITLE
Add erasure type to storj_file_meta_t, not the full erasure json string

### DIFF
--- a/src/storj.c
+++ b/src/storj.c
@@ -251,6 +251,7 @@ static void list_files_request_worker(uv_work_t *work)
     struct json_object *hmac;
     struct json_object *hmac_value;
     struct json_object *erasure;
+    struct json_object *erasure_type;
     struct json_object *index;
 
     for (int i = 0; i < num_files; i++) {
@@ -265,6 +266,7 @@ static void list_files_request_worker(uv_work_t *work)
         json_object_object_get_ex(file, "hmac", &hmac);
         json_object_object_get_ex(hmac, "value", &hmac_value);
         json_object_object_get_ex(file, "erasure", &erasure);
+        json_object_object_get_ex(erasure, "type", &erasure_type);
         json_object_object_get_ex(file, "index", &index);
 
         storj_file_meta_t *file = &req->files[i];
@@ -272,7 +274,7 @@ static void list_files_request_worker(uv_work_t *work)
         file->created = json_object_get_string(created);
         file->mimetype = json_object_get_string(mimetype);
         file->size = json_object_get_int64(size);
-        file->erasure = json_object_get_string(erasure);
+        file->erasure = json_object_get_string(erasure_type);
         file->index = json_object_get_string(index);
         file->hmac = json_object_get_string(hmac_value);
         file->id = json_object_get_string(id);
@@ -325,6 +327,7 @@ static void get_file_info_request_worker(uv_work_t *work)
     struct json_object *hmac;
     struct json_object *hmac_value;
     struct json_object *erasure;
+    struct json_object *erasure_type;
     struct json_object *index;
 
     json_object_object_get_ex(req->response, "filename", &filename);
@@ -336,13 +339,14 @@ static void get_file_info_request_worker(uv_work_t *work)
     json_object_object_get_ex(req->response, "hmac", &hmac);
     json_object_object_get_ex(hmac, "value", &hmac_value);
     json_object_object_get_ex(req->response, "erasure", &erasure);
+    json_object_object_get_ex(erasure, "type", &erasure_type);
     json_object_object_get_ex(req->response, "index", &index);
 
     req->file = malloc(sizeof(storj_file_meta_t));
     req->file->created = json_object_get_string(created);
     req->file->mimetype = json_object_get_string(mimetype);
     req->file->size = json_object_get_int64(size);
-    req->file->erasure = json_object_get_string(erasure);
+    req->file->erasure = json_object_get_string(erasure_type);
     req->file->index = json_object_get_string(index);
     req->file->hmac = json_object_get_string(hmac_value);
     req->file->id = json_object_get_string(id);


### PR DESCRIPTION
The erasure meta info is returned by the bridge in the form of `{
"type": "reedsolomon" }`. Only the `reedsolomon` string should be added to `storj_file_meta_t`, not the full json string.