### PR TITLE
curl-download on Debian/Windows 10

### DIFF
--- a/depends/packages/gnutls.mk
+++ b/depends/packages/gnutls.mk
@@ -1,6 +1,6 @@
-package=gnutls
+ package=gnutls
 $(package)_version=3.5.8
-$(package)_download_path=ftp://ftp.gnutls.org/gcrypt/gnutls/v3.5/gnutls-$($(package)_version).tar.xz
+$(package)_download_path=https://ftp.osuosl.org/pub/blfs/conglomeration/gnutls/gnutls-$($(package)_version).tar.xz
 $(package)_file_name=$(package)-$($(package)_version).tar.xz
 $(package)_sha256_hash=0e97f243ae72b70307d684b84c7fe679385aa7a7a0e37e5be810193dcc17d4ff
 


### PR DESCRIPTION
The curl-download of gnutls does not work with debian within Windows 10 (Subsystem). I used a different repository-position that seemed to work - though the SHA-hash does not match. At least my build gets a bit further. Maybe someone can check that curl-command or use a different URL for curl.