### PR TITLE
Patch for cross-compiling DLLs on Ubuntu 14.04

### DIFF
--- a/depends/packages/gnutls.mk
+++ b/depends/packages/gnutls.mk
@@ -17,7 +17,7 @@ $(package)_config_env_i686-pc-linux-gnu=NETTLE_CFLAGS="-static" GMP_CFLAGS="-sta
 
 # mingw dll specific settings
 ifeq ($(BUILD_DLL), 1)
-$(package)_config_env_x86_64-w64-mingw32=PKG_CONFIG_LIBDIR="$(PREFIX_DIR)/lib/pkgconfig" CFLAGS="-I$(PREFIX_DIR)include -L$(PREFIX_DIR)lib"
+$(package)_config_env_x86_64-w64-mingw32=PKG_CONFIG_LIBDIR="$(PREFIX_DIR)/lib/pkgconfig" CFLAGS="-I$(PREFIX_DIR)include -L$(PREFIX_DIR)lib -D_WIN32_WINNT=0x0600 -DNCRYPT_PAD_PKCS1_FLAG=2 -DNCRYPT_SHA1_ALGORITHM=BCRYPT_SHA1_ALGORITHM -DNCRYPT_SHA256_ALGORITHM=BCRYPT_SHA256_ALGORITHM -DCERT_NCRYPT_KEY_HANDLE_TRANSFER_PROP_ID=99"
 endif
 
 # set settings based on host


### PR DESCRIPTION
I want to automatically cross-compile the Windows DLLs on Travis CI
(Ubuntu 14.04) to include them in the Github releases of java-libstorj.

The cross-compile fails on Ubuntu 14.04 unless the define declarations
in this PR are added to gnutls.mk.